### PR TITLE
Adding `generator` field per #6.

### DIFF
--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -254,6 +254,7 @@ the `annotation` object:
 |----|--------------|-------|-----------|
 |`sample_start`|true|uint|The sample index at which this segment takes effect.|
 |`sample_count`|true|uint|The number of samples that this segment applies to. |
+|`generator`|false|string|Human-readable name of the entity that created this annotation.|
 |`comment`|false|string|A human-readable comment.|
 |`freq_lower_edge`|false|double|The lower edge of the frequency band of a signal feature that this annotation describes.|
 |`freq_upper_edge`|false|double|The upper edge of the frequency band of a signal feature that this annotation describes. |


### PR DESCRIPTION
Resolves #6 by providing an optional field by which the user can indicate the source of an annotation.