### PR TITLE
Prohibiting the carrying over of metadata between segments.

### DIFF
--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -164,7 +164,11 @@ in use, or omitted entirely (including the colon).
    `top-level object`.
 3. The top-level object MUST contain three objects named `global`, `capture`,
    and `annotations`.
-   
+4. Metadata name/value pairs SHALL NOT be assumed to have carried over between
+   segments. If a name/value pair applies to a particular segment, then it must
+   appear in that segment, even if the value is unchanged relative to the
+   previous segment.
+
 #### Datatypes
 
 The values in each name/value pair must be one of the following datatypes:


### PR DESCRIPTION
I tried to do this in the simplest way possible by stating this in a single location. Open to feedback on better places to put this or state it more clearly.

This addresses #22.