### PR TITLE
spec: Annotation frequencies are in (complex) base band

### DIFF
--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -259,8 +259,8 @@ the `annotation` object:
 |`sample_start`|true|uint|The sample index at which this segment takes effect.|
 |`sample_count`|true|uint|The number of samples that this segment applies to. |
 |`comment`|false|string|A human-readable comment.|
-|`freq_lower_edge`|false|double|The lower edge of the frequency band of a signal feature that this annotation describes.|
-|`freq_upper_edge`|false|double|The upper edge of the frequency band of a signal feature that this annotation describes. |
+|`freq_lower_edge`|false|double|The lower edge (in the baseband) of the frequency band of a signal feature that this annotation describes.|
+|`freq_upper_edge`|false|double|The upper edge (in the baseband) of the frequency band of a signal feature that this annotation describes.|
 |`latitude`|false|need a standard?| |
 |`longitude`|false|need a standard?| |
 


### PR DESCRIPTION
The spec is not explicit about if the frequencies of an annotation are in passband or baseband.