### PR TITLE
Add test for and fix SigMFFile default constructor

### DIFF
--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -129,7 +129,10 @@ class SigMFFile(object):
         """
         Returns a dictionary with all the global info.
         """
-        return self._metadata.get(self.GLOBAL_KEY, {})
+        try:
+            return self._metadata.get(self.GLOBAL_KEY, {})
+        except AttributeError:
+            return {}
 
     def set_global_field(self, key, value):
         """
@@ -258,4 +261,3 @@ class SigMFFile(object):
             indent=4 if pretty else None,
             separators=(',', ': ') if pretty else None,
         )
-

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -123,3 +123,6 @@ def test_invalid_capture_seq():
 
 def test_assert_empty():
     pass
+
+def test_default_constructor():
+    sigmf.SigMFFile()


### PR DESCRIPTION
The SigMFFile class contained the following, which makes it appear you wanted to allow initializing a SigMFFile with no input and have it use some sane default schema:

```
    def __init__(
            self,
            metadata=None,
            data_file=None,
            global_info=None,
    ):
        self.version = None
        self.schema = None
        if metadata is None:
            self._metadata = get_default_metadata(self.get_schema())
        [...]
```

But `__init__` as written has a circular dependency on `self._metadata`, so I get the following:

```
>>> from sigmf import SigMFFile
>>> f = SigMFFile()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dja/dev/SigMF/sigmf/sigmffile.py", line 80, in __init__
    self._metadata = get_default_metadata(self.get_schema())
  File "/home/dja/dev/SigMF/sigmf/sigmffile.py", line 113, in get_schema
    current_metadata_version = self.get_global_info().get(self.VERSION_KEY)
  File "/home/dja/dev/SigMF/sigmf/sigmffile.py", line 132, in get_global_info
    return self._metadata.get(self.GLOBAL_KEY, {})
AttributeError: 'SigMFFile' object has no attribute '_metadata'
```

This commit adds a unit test for the default constructor and then fixes the circular dependency.