### PR TITLE
Update example metadata for PR #32

### DIFF
--- a/example_metadata.py
+++ b/example_metadata.py
@@ -1,4 +1,4 @@
-# 
+#
 # Warning: this is not strict JSON, this is python to allow inline comment
 #
 
@@ -13,13 +13,13 @@
     "capture": [
         # The `capture` object contains a list of segments, sorted by the `sample_start` value
         {
-            "sample_start": 0,              # The sample index that these parameters take effect.
+            "core:sample_start": 0,         # The sample index that these parameters take effect.
             "core:sample_rate": 10000000,   # The sample rate of the recording (10 MHz, here).
             "core:frequency": 900000000,    # The center frequency of the recording (900 MHz, here).
             "core:time": "2017-02-01T11:33:17,053240428+01:00",
         },
         {
-            "sample_start": 100000,         # Mandatory
+            "core:sample_start": 100000,    # Mandatory
             "core:sample_rate": 10000000,   # 10 MHz
             "core:frequency": 950000000,    # Now at 950 MHz
         },
@@ -28,10 +28,9 @@
     "annotations": [
         # The `annotations` object contains a list of segments, sorted by the `sample_start` value
         {
-            "sample_start": 1000000,        # The sample index at which this annotation first applies.
-            "sample_count": 120000,         # The number of samples that this annotation applies to.
+            "core:sample_start": 1000000,   # The sample index at which this annotation first applies.
+            "core:sample_count": 120000,    # The number of samples that this annotation applies to.
             "core:comment": "Some text comment about stuff happening",
         },
     ],
 }
-


### PR DESCRIPTION
The spec states "Each capture segment must contain a core:sample_start
name/value pair", and PR #32 makes the namespace required, so the
example should reflect that.