### PR TITLE
Removing the `datapath` key, adding requirement for filename.

### DIFF
--- a/example_metadata.py
+++ b/example_metadata.py
@@ -5,7 +5,6 @@
 {
     "global": {
         "core:datatype": "cf32",            # The datatype of the recording (here, complex 32-bit float)
-        "core:datapath": "./samples.bin",   # The filepath of the dataset.
         "core:version": "0.0.1",            # Version of the SigMF spec used.
         "core:description": "An example metadafile for a SigMF recording.",
     },

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -105,6 +105,8 @@ file contains information that describes the dataset.
 3. The metadata file MUST be stored in UTF-8 encoding.
 3. The metadata file MUST have a `.meta` filename extension.
 4. The dataset file MUST have a `.data` filename extension.
+5. The names of the metadata and dataset files must be identical (excepting
+   their extensions).
 
 ### Dataset Format
 
@@ -205,7 +207,6 @@ the `global` object:
 |name|required|type|description|
 |----|--------------|-------|-----------|
 |`datatype`|true|string|The format of the stored samples in the dataset file. Its value must be a valid SigMF dataset format type string.|
-|`datapath`|true|string|The filepath to the dataset file described by the SigMF file. The path can be absolute or relative.|
 |`version`|true|string|The version of the SigMF specification used to create the metadata file.|
 |`sha512`|false|string|The SHA512 hash of the dataset file associated with the SigMF file.|
 |`offset`|false|uint64|The index number of the first sample in the dataset. This value defaults to zero. Typically used when a recording is split over multiple files.|

--- a/sigmf/schema.json
+++ b/sigmf/schema.json
@@ -34,11 +34,6 @@
 				"pattern": "",
 				"help": "ISO 8601-formatted date (e.g., 2017-02-01T15:05:03+00:00)"
 			},
-			"core:datapath": {
-				"type": "string",
-				"required": true,
-				"help": "Location of the sample data file"
-			},
 			"core:sha512": {
 				"type": "string",
 				"required": false,

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -55,7 +55,7 @@ class SigMFFile(object):
 
     Parameters:
     metadata    -- Metadata. Either a string, or a dictionary.
-    data_file   -- Path to the corresponding data file (optional).
+    data_file   -- Path to the corresponding data file.
     global_info -- Dictionary containing global header info.
     """
     START_INDEX_KEY = "core:sample_start"
@@ -63,7 +63,6 @@ class SigMFFile(object):
     START_OFFSET_KEY = "core:offset"
     HASH_KEY = "core:sha512"
     VERSION_KEY = "core:version"
-    FILENAME_KEY = "core:datapath"
     GLOBAL_KEY = "global"
     CAPTURE_KEY = "capture"
     ANNOTATION_KEY = "annotation"
@@ -85,8 +84,6 @@ class SigMFFile(object):
         if global_info is not None:
             self.set_global_info(global_info)
         self.data_file = data_file
-        if self.data_file is not None:
-            self.set_global_field(self.FILENAME_KEY, self.data_file)
 
     def _get_start_offset(self):
         """

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -27,7 +27,6 @@ MD_VALID = """
 {
     "global": {
         "core:datatype": "cf32",
-        "core:datapath": "foo.dat",
         "core:offset": 0,
         "core:version": "1.0.0",
         "core:license": "CC0",
@@ -65,7 +64,6 @@ MD_INVALID_SEQUENCE_CAP = """
 {
     "global": {
         "core:datatype": "cf32",
-        "core:datapath": "foo.dat"
     },
 
     "capture": [
@@ -89,7 +87,6 @@ MD_INVALID_SEQUENCE_ANN = """
 {
     "global": {
         "core:datatype": "cf32",
-        "core:datapath": "foo.dat"
     },
 
     "capture": [


### PR DESCRIPTION
Okay, this makes the changes discussed in #16.

This one was more than just a spec change since `datapath` was used in the Python validator. Thankfully, it was already built to use a `file_path` parameter to start with, so it wasn't a problem to remove it.