### PR TITLE
Making `sample_rate` constant in a recording.

### DIFF
--- a/example_metadata.py
+++ b/example_metadata.py
@@ -5,7 +5,6 @@
 {
     "global": {
         "core:datatype": "cf32",            # The datatype of the recording (here, complex 32-bit float)
-        "core:datapath": "./samples.bin",   # The filepath of the dataset.
         "core:sample_rate": 10000000,       # The sample rate of the recording (10 MHz, here).
         "core:version": "0.0.1",            # Version of the SigMF spec used.
         "core:description": "An example metadafile for a SigMF recording.",

--- a/example_metadata.py
+++ b/example_metadata.py
@@ -5,6 +5,8 @@
 {
     "global": {
         "core:datatype": "cf32",            # The datatype of the recording (here, complex 32-bit float)
+        "core:datapath": "./samples.bin",   # The filepath of the dataset.
+        "core:sample_rate": 10000000,       # The sample rate of the recording (10 MHz, here).
         "core:version": "0.0.1",            # Version of the SigMF spec used.
         "core:description": "An example metadafile for a SigMF recording.",
     },
@@ -13,13 +15,11 @@
         # The `capture` object contains a list of segments, sorted by the `sample_start` value
         {
             "core:sample_start": 0,         # The sample index that these parameters take effect.
-            "core:sample_rate": 10000000,   # The sample rate of the recording (10 MHz, here).
             "core:frequency": 900000000,    # The center frequency of the recording (900 MHz, here).
             "core:time": "2017-02-01T11:33:17,053240428+01:00",
         },
         {
             "core:sample_start": 100000,    # Mandatory
-            "core:sample_rate": 10000000,   # 10 MHz
             "core:frequency": 950000000,    # Now at 950 MHz
         },
     ],

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -208,7 +208,7 @@ the `global` object:
 |----|--------------|-------|-----------|
 |`datatype`|true|string|The format of the stored samples in the dataset file. Its value must be a valid SigMF dataset format type string.|
 |`datapath`|true|string|The filepath to the dataset file described by the SigMF file. The path can be absolute or relative.|
-|`sample_rate`|false|double|The sample rate of the signal in Samples per Second.|
+|`sample_rate`|false|double|The sample rate of the signal in samples per second.|
 |`version`|true|string|The version of the SigMF specification used to create the metadata file.|
 |`sha512`|false|string|The SHA512 hash of the dataset file associated with the SigMF file.|
 |`offset`|false|uint64|The index number of the first sample in the dataset. This value defaults to zero. Typically used when a recording is split over multiple files.|

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -207,7 +207,6 @@ the `global` object:
 |name|required|type|description|
 |----|--------------|-------|-----------|
 |`datatype`|true|string|The format of the stored samples in the dataset file. Its value must be a valid SigMF dataset format type string.|
-|`datapath`|true|string|The filepath to the dataset file described by the SigMF file. The path can be absolute or relative.|
 |`sample_rate`|false|double|The sample rate of the signal in samples per second.|
 |`version`|true|string|The version of the SigMF specification used to create the metadata file.|
 |`sha512`|false|string|The SHA512 hash of the dataset file associated with the SigMF file.|

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -207,6 +207,8 @@ the `global` object:
 |name|required|type|description|
 |----|--------------|-------|-----------|
 |`datatype`|true|string|The format of the stored samples in the dataset file. Its value must be a valid SigMF dataset format type string.|
+|`datapath`|true|string|The filepath to the dataset file described by the SigMF file. The path can be absolute or relative.|
+|`sample_rate`|false|double|The sample rate of the signal in Samples per Second.|
 |`version`|true|string|The version of the SigMF specification used to create the metadata file.|
 |`sha512`|false|string|The SHA512 hash of the dataset file associated with the SigMF file.|
 |`offset`|false|uint64|The index number of the first sample in the dataset. This value defaults to zero. Typically used when a recording is split over multiple files.|
@@ -237,7 +239,6 @@ capture segment objects:
 |----|--------------|-------|-----------|
 |`sample_start`|true|uint|The sample index at which this segment takes effect.|
 |`frequency`|false|double|The center frequency of the signal in Hz.|
-|`sample_rate`|false|double|The sample rate of the signal in Samples per Second.|
 |`time`|false|string|An ISO-8601 formatted string indicating the timestamp of the sample index specified by `sample_start`.|
 
 #### Annotation Array


### PR DESCRIPTION
Okay, `sample_rate` is now defined in the `global` object, and is thus constant for a recording.

This is the result of discussions in #28 