### PR TITLE
Allow setting fields that aren't defined in schema

### DIFF
--- a/sigmf/validate.py
+++ b/sigmf/validate.py
@@ -58,14 +58,14 @@ def validate_key(data_value, ref_dict, section, key):
     key -- The key of this key/value pair ("core:Version", etc.). This is for
            better error reporting only.
     """
-    if ref_dict["required"] and data_value is None:
+    if ref_dict.get('required') and data_value is None:
         return ValidationResult(
             False,
             "In Section `{sec}', an entry is missing required key `{key}'.".format(
                 sec=section,
                 key=key
             ))
-    if not match_type(data_value, ref_dict["type"]):
+    if 'type' in ref_dict and not match_type(data_value, ref_dict["type"]):
         return ValidationResult(
             False,
             "In Section `{sec}', entry `{key}={value}' is not of type `{type}'.".format(
@@ -170,6 +170,6 @@ if __name__ == "__main__":
     ref_dict_ = json.load(open("schema.json"))
     print(validate(data_dict_, ref_dict_))
 
-				# "py_re": "^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$"
+    # "py_re": "^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:Z|[+-][01]\d:[0-5]\d)$"
 
-				# "py_re": "\d+\.\d+\.\d+"
+    # "py_re": "\d+\.\d+\.\d+"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -120,3 +120,7 @@ def test_assert_empty():
 
 def test_default_constructor():
     sigmf.SigMFFile()
+
+def test_set_non_required_global_field():
+    f = sigmf.SigMFFile()
+    f.set_global_field('this_is:not_in_the_schema', None)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -34,7 +34,6 @@ MD_VALID = """
         "core:url": "foo",
         "core:sha512": "69a014f8855058d25b30b1caf4f9d15bb7b38afa26e28b24a63545734e534a861d658eddae1dbc666b33ca1d18c1ca85722f1f2f010703a7dbbef08189a1d0e5"
     },
-
     "capture": [
         {
             "core:sample_start": 0,
@@ -63,9 +62,8 @@ MD_VALID = """
 MD_INVALID_SEQUENCE_CAP = """
 {
     "global": {
-        "core:datatype": "cf32",
+        "core:datatype": "cf32"
     },
-
     "capture": [
         {
             "core:sample_start": 10
@@ -86,9 +84,8 @@ MD_INVALID_SEQUENCE_CAP = """
 MD_INVALID_SEQUENCE_ANN = """
 {
     "global": {
-        "core:datatype": "cf32",
+        "core:datatype": "cf32"
     },
-
     "capture": [
         {
             "core:sample_start": 0


### PR DESCRIPTION
The spec says anything outside the defined core fields should be
acceptable and ignored. The code as fails when adding a previously
undefined global field. This commit adds a unit test for this case and
implements the correct behavior.

Also fix a JSON notation issue in test_validation.py.