### PR TITLE
Fixing error raised from installed package when looking for the JSON schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Programming Language :: Python :: 3.7'
     ],
     packages=['sigmf'],
+    package_data = {'sigmf': ['*.json']},
     install_requires=['six', 'numpy'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest>3'],


### PR DESCRIPTION
By default, schema.json is not included in the installation package.  This causes errors when running a simple SigMF test:

```
from sigmf.sigmffile import SigMFFile

sf = SigMFFile()
```
yields: 

`FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.5/dist-packages/SigMF-0.0.1-py3.5.egg/sigmf/schema.json'`

This pull request includes json files in the installation package.