### PR TITLE
Clarifying the order of complex samples per #65.

### DIFF
--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -170,6 +170,9 @@ The samples should be written to the dataset file without separation, and the
 dataset file MUST NOT contain any other characters (e.g., delimiters,
 whitespace, line-endings, `EOF` characters, etc.,).
 
+Complex samples should be interleaved, with the in-phase component first (e.g.
+`IQIQ...` instead of `QIQI...`).
+
 ### Metadata Format
 
 SigMF is written in JSON and takes the form of JSON name/value pairs which are

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -170,8 +170,8 @@ The samples should be written to the dataset file without separation, and the
 dataset file MUST NOT contain any other characters (e.g., delimiters,
 whitespace, line-endings, `EOF` characters, etc.,).
 
-Complex samples should be interleaved, with the in-phase component first (e.g.
-`IQIQ...` instead of `QIQI...`).
+Complex samples should be interleaved, with the in-phase component first (i.e.,
+`I[0]` `Q[0]` `I[1]` `Q[1]` ... `I[n]` `Q[n]`).
 
 ### Metadata Format
 


### PR DESCRIPTION
Adds a note to the specification document clarifying IQ vs QI ordering.

I don't think this spec change affects validation in any way, so this should be all that's required.