### PR TITLE
Read and write POSIX.1-2001 format tar archives

### DIFF
--- a/sigmf/archive.py
+++ b/sigmf/archive.py
@@ -75,7 +75,9 @@ class SigMFArchive(object):
 
         archive_name = self._get_archive_name()
         sigmf_fileobj = self._get_output_fileobj()
-        sigmf_archive = tarfile.TarFile(mode="w", fileobj=sigmf_fileobj)
+        sigmf_archive = tarfile.TarFile(mode="w", 
+                                        fileobj=sigmf_fileobj,
+                                        format=tarfile.PAX_FORMAT)
         tmpdir = tempfile.mkdtemp()
         sigmf_md_filename = archive_name + SIGMF_METADATA_EXT
         sigmf_md_path = os.path.join(tmpdir, sigmf_md_filename)

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -300,7 +300,7 @@ def fromarchive(archive_path, dir=None):
     if not dir:
         dir = tempfile.mkdtemp()
 
-    archive = tarfile.open(archive_path)
+    archive = tarfile.open(archive_path, mode="r", format=tarfile.PAX_FORMAT)
     members = archive.getmembers()
 
     try:

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -16,7 +16,7 @@ from .testdata import TEST_FLOAT32_DATA, TEST_METADATA
 
 def create_test_archive(test_sigmffile, tmpfile):
     sigmf_archive = test_sigmffile.archive(fileobj=tmpfile)
-    sigmf_tarfile = tarfile.open(sigmf_archive, mode="r")
+    sigmf_tarfile = tarfile.open(sigmf_archive, mode="r", format=tarfile.PAX_FORMAT)
     return sigmf_tarfile
 
 
@@ -136,3 +136,9 @@ def test_contents(test_sigmffile):
         data = np.fromstring(datfile_reader.read(), dtype=np.float32)
 
         assert np.array_equal(data, TEST_FLOAT32_DATA)
+
+
+def test_tarfile_type(test_sigmffile):
+    with tempfile.NamedTemporaryFile() as t:
+        sigmf_tarfile = create_test_archive(test_sigmffile, t)
+        assert sigmf_tarfile.format == tarfile.PAX_FORMAT


### PR DESCRIPTION
Thanks to @pwicks86 for catching the discrepancy between the spec and the implementation!

Closes issue #61.