### PR TITLE
Removing `length` field from `captures`.

### DIFF
--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -327,7 +327,6 @@ capture segment objects:
 |name|required|type|description|
 |----|--------------|-------|-----------|
 |`sample_start`|true|uint|The sample index at which this segment takes effect.|
-|`length`|false|uint|The length of this capture segment, in number of samples.|
 |`frequency`|false|double|The center frequency of the signal in Hz.|
 |`datetime`|false|string|An ISO-8601 string indicating the timestamp of the sample index specified by `sample_start`. More details, below.|
 


### PR DESCRIPTION
Per the discussion at GRCon, this field is unnecessary, especially given
SigMF's focus on being a storage format as opposed to a transport
format.

@storborg @pwicks86 - This is a simple change, but this look good to you?