### PR TITLE
Modifications to `extensions` per #103.

### DIFF
--- a/extensions/adsb.sigmf-ext.md
+++ b/extensions/adsb.sigmf-ext.md
@@ -1,15 +1,20 @@
 # ADS-B Extension v1.0.0
-The Automatic Dependent Surveillance-Broadcast (`adsb`) namespace extension defines dynamic properties of ADS-B signals extending `annotations`.
 
-## Global
-The following names are specified in the `adsb` namespace and should be used in the `global` object:
+The Automatic Dependent Surveillance-Broadcast (`adsb`) namespace extension
+defines dynamic properties of ADS-B signals extending `annotations`.
 
-|name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
-|`version`|true|string|N/A|The version of the `adsb` extension used to create the metadata file.|
+## 1 Global
 
-## Annotations
-The following names are specified in the `adsb` namespace and should be used in the `annotations` object:
+`adsb` does not extend [Global](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#global-object).
+
+## 2 Captures
+
+`signal` does not extend [Captures](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#captures-array).
+
+## 3 Annotations
+
+The following names are specified in the `adsb` namespace and should be used in
+the `annotations` object:
 
 |name|required|type|unit|description|
 |----|--------------|-------|-------|-----------|
@@ -17,3 +22,7 @@ The following names are specified in the `adsb` namespace and should be used in 
 |`message_type`|true|int|N/A|Indicates the type of data in a Mode S Extended signal.  The message type code range is from 0 to 31. The type of messages are aircraft identification (1-4), surface position (5-8), airborne position with barometric (9-18), airborne velocities (19), airborne position with GNSS (20-22), testing (23), reserved (24-27, 30), Emergency/Airborne Collision Avoidance System (ACAS) status (28), trajectory change (29), and aircraft operational status (31).  A signal with a Mode S Short downlink format does not contains a message and is represented by 0.
 |`ICA_address`|true|float|N/A|The International Civil Aviation Organization (ICAO) address of the ADS-B signal.|
 |`binary`|true|string|N/A|The binary signal, either 56 bits (Mode S Short) or 112 bits (Mode S Extended).|
+
+## 4 Examples
+
+No `adsb` examples.

--- a/extensions/antenna.sigmf-ext.md
+++ b/extensions/antenna.sigmf-ext.md
@@ -1,8 +1,8 @@
-# Antenna Extension v0.9.0
+# Antenna Extension v1.0.0
 
 The `antenna` namespace extension defines static antenna parameters extending `global` and dynamic antenna parameters extending `annotations`.
 
-## Global
+## 1 Global
 
 The following names are specified in the `antenna` namespace and should be used in
 the `global` object:
@@ -23,9 +23,12 @@ the `global` object:
 |`cable_loss`|false|float|dB|Cable loss for cable connecting antenna and preselector.|
 |`steerable`|false|boolean|N/A|Defines if the antenna is steerable or not.|
 |`mobile`|false|boolean|N/A|Defines if the antenna is mobile or not.|
-|`version`|true|string|N/A|The version of the `antenna` extension used to create the metadata file.|
 
-## Annotations
+## 2 Captures
+
+`antenna` does not extend [Captures](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#captures-array).
+
+## 3 Annotations
 
 The following names are specified in the `antenna` namespace and should be used in
 the `annotations` object:
@@ -35,3 +38,7 @@ the `annotations` object:
 |`azimuth_angle`|false|float|degrees|Angle of main beam in azimuthal plane from North.|
 |`elevation_angle`|false|float|degrees|Angle of main beam in elevation plane from horizontal.|
 |`polarization`|false|float|string|E.g. `"vertical"`, `"horizontal"`, `"slant-45"`, `"left-hand circular"`, `"right-hand circular"`.|
+
+## 4 Examples
+
+No `antenna` examples.

--- a/extensions/capture_details.sigmf-ext.md
+++ b/extensions/capture_details.sigmf-ext.md
@@ -1,17 +1,16 @@
 # Capture Details Extension v1.0.0
-The `capture_details` namespace extension defines static IQ capture parameters extending `captures` and dynamic IQ capture parameters extending `annotations`.
 
-## Global
+The `capture_details` namespace extension defines static IQ capture parameters
+extending `captures` and dynamic IQ capture parameters extending `annotations`.
 
-The following names are specified in the `capture_details` namespace and should be used in the `global` object:
+## 1 Global
 
-|name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
-|`version`|true|string|N/A|The version of the `capture_details` extension used to create the metadata file.|
+`capture_details` does not extend [Global](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#global-object).
 
-## Captures
+## 2 Captures
 
-The following names are specified in the `capture_details` namespace and should be used in the `captures` object:
+The following names are specified in the `capture_details` namespace and should
+be used in the `captures` object:
 
 |name|required|type|unit|description|
 |----|--------------|-------|-------|-----------|
@@ -23,7 +22,7 @@ The following names are specified in the `capture_details` namespace and should 
 |`source_file`|true|string|N/A|RF IQ recording filename that was used to create the file `N.sigmf-data`.  The file `N.sigmf-data` may be the same or an edited versions of the `source_file`.|
 |`gain`|false|float|dB|Input gain.|
 
-## Annotations
+## 3 Annotations
 
 The following names are specified in the `capture_details` namespace and should be used in the `annotations` object:
 
@@ -31,3 +30,7 @@ The following names are specified in the `capture_details` namespace and should 
 |----|--------------|-------|-------|-----------|
 |`SNRdB`|true|float|dB|Root mean square (RMS) calculation of signal to noise ratio (SNR). The calculation is over windows of known signal and no known signal.|
 |`signal_reference_number`|true|string|N/A|Sequential reference labels for the elements that form the sequence of signals identified in a SigMF dataset file. The format of the string is the filename followed by an index that increases with each decoded signal.  An example is a recording dataset file named `N.sigmf-data` would have signal numbers starting with `N-1`, `N-2`, `N-3`...|
+
+## 4 Examples
+
+No `capture_details` examples.

--- a/extensions/rfml.sigmf-ext.md
+++ b/extensions/rfml.sigmf-ext.md
@@ -1,20 +1,30 @@
 # RFML Extension v1.0.0
-The radio frequency machine learning (`rfml`) namespace extension defines the protocol, manufacturer, and device labeling scheme for RF bursts.
 
-## Global
+The radio frequency machine learning (`rfml`) namespace extension defines the
+protocol, manufacturer, and device labeling scheme for RF bursts.
 
-The following names are specified in the `rfml` namespace and should be used in the `global` object:
+## 1 Global
+
+The following names are specified in the `rfml` namespace and should be used in
+the `global` object:
 
 |name|required|type|unit|description|
 |----|--------------|-------|-------|-----------|
 |`label_hierarchy`|true|array|N/A|Defines hierarchy of the fields in the label array.|
-|`version`|true|string|N/A|The version of the `rfml` extension used to create the metadata file.|
 
+## 2 Captures
 
-## Annotations
+`rfml` does not extend [Captures](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#captures-array).
 
-The following names are specified in the `rfml` namespace and should be used in the `annotations` object:
+## 3 Annotations
+
+The following names are specified in the `rfml` namespace and should be used in
+the `annotations` object:
 
 |name|required|type|unit|description|
 |----|--------------|-------|-------|-----------|
 |`label`|true|array|N/A|An array of hierarchical labels that describe this annotation. The label `device_type` is the type of RF transmitter or signal source.  The label `manufacturer_ID` is the manufacturer of the transmitter. The label `device_ID` is the source of the RF signal.|
+
+## 4 Examples
+
+No `rfml` examples.

--- a/extensions/signal.sigmf-ext.md
+++ b/extensions/signal.sigmf-ext.md
@@ -1,4 +1,4 @@
-# The `signal` SigMF Extension Namespace v0.1.0
+# The `signal` SigMF Extension Namespace v1.0.0
 
 This document defines the `signal` extension namespace for the Signal Metadata
 Format (SigMF) specification. This extension namespace defines how to describe

--- a/extensions/wifi.sigmf-ext.md
+++ b/extensions/wifi.sigmf-ext.md
@@ -1,15 +1,17 @@
 ## Wi-Fi Extension v1.0.0
-The `wifi`namespace extension defines dynamic Wi-Fi burst parameters extending `annotations`.
 
-## Global
+The `wifi`namespace extension defines dynamic Wi-Fi burst parameters extending
+`annotations`.
 
-The following names are specified in the `wifi` namespace and should be used in the `global` object:
+## 1 Global
 
-|name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
-|`version`|true|string|N/A|The version of the `wifi` extension used to create the metadata file.|
+`wifi` does not extend [Global](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#global-object).
 
-## Annotations
+## 2 Captures
+
+`wifi` does not extend [Captures](https://github.com/gnuradio/SigMF/blob/master/sigmf-spec.md#captures-array).
+
+## 3 Annotations
 
 The following names are specified in the `wifi` namespace and should be used in the `annotations` object:
 
@@ -31,3 +33,7 @@ The following names are specified in the `wifi` namespace and should be used in 
 |`start_of_packet`|true|float|samples|Starting sample of captured Wi-Fi burst.|
 |`stop_of_packet`|true|float|samples|Stopping sample of captured Wi-Fi burst.|
 |`number_of_samples_in_packet`|true|float|samples|Number of downsampled IQ samples in Wi-Fi burst.|
+
+## 4 Examples
+
+No `wifi` examples.

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -330,9 +330,8 @@ example including the optional third altitude value is shown below:
 
 ##### The `extensions` Field
 
-The `core:extensions` field in the `global` object is a JSON array of objects
-that describe SigMF extensions. These `extensions objects` have the following
-names defined in the `core` namespace:
+The `core:extensions` field in the `global` object is a JSON array of _extension objects_
+that describe SigMF extensions. `Extension objects` MUST contain the three key/value pairs defined below, and MUST NOT contain any other fields.
 
 |name|required|type|description|
 |----|--------------|-------|-----------|

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -31,34 +31,34 @@ This document is available under the [CC-BY-SA License](http://creativecommons.o
 **Table of Contents**
 
 * [Signal Metadata Format Specification v0.0.2](#signal-metadata-format-specification-v002)
-    * [Abstract](#abstract)
-    * [Status of this Document](#status-of-this-document)
-    * [Copyright Notice](#copyright-notice)
-    * [Table of Contents](#table-of-contents)
-    * [Introduction](#introduction)
-    * [Conventions Used in this Document](#conventions-used-in-this-document)
-    * [Specification](#specification)
-        * [Files](#files)
-            * [SigMF Archives](#sigmf-archives)
-        * [Dataset Format](#dataset-format)
-        * [Metadata Format](#metadata-format)
-            * [Datatypes](#datatypes)
-            * [Namespaces](#namespaces)
-                * [Extension Namespaces](#extension-namespaces)
-                * [Canonical Extension Namespaces](#canonical-extension-namespaces)
-            * [Global Object](#global-object)
-                * [The `extensions` Field](#the-extensions-field)
-            * [Captures Array](#captures-array)
-                * [Capture Segment Objects](#capture-segment-objects)
-                    * [The `global_index` Pair](#the-globalindex-pair)
-                    * [The `datetime` Pair](#the-datetime-pair)
-            * [Annotations Array](#annotations-array)
-                * [Annotation Segment Objects](#annotation-segment-objects)
-        * [Dataset Licensing](#dataset-licensing)
-        * [SigMF Compliance by Applications](#sigmf-compliance-by-applications)
-    * [Example](#example)
-    * [Citing SigMF](#citing-sigmf)
-    * [Acknowledgements](#acknowledgements)
+  * [Abstract](#abstract)
+  * [Status of this Document](#status-of-this-document)
+  * [Copyright Notice](#copyright-notice)
+  * [Table of Contents](#table-of-contents)
+  * [Introduction](#introduction)
+  * [Conventions Used in this Document](#conventions-used-in-this-document)
+  * [Specification](#specification)
+    * [Files](#files)
+      * [SigMF Archives](#sigmf-archives)
+    * [Dataset Format](#dataset-format)
+    * [Metadata Format](#metadata-format)
+      * [Datatypes](#datatypes)
+      * [Namespaces](#namespaces)
+        * [Extension Namespaces](#extension-namespaces)
+        * [Canonical Extension Namespaces](#canonical-extension-namespaces)
+      * [Global Object](#global-object)
+        * [The `extensions` Field](#the-extensions-field)
+      * [Captures Array](#captures-array)
+        * [Capture Segment Objects](#capture-segment-objects)
+          * [The `global_index` Pair](#the-globalindex-pair)
+          * [The `datetime` Pair](#the-datetime-pair)
+      * [Annotations Array](#annotations-array)
+        * [Annotation Segment Objects](#annotation-segment-objects)
+    * [Dataset Licensing](#dataset-licensing)
+    * [SigMF Compliance by Applications](#sigmf-compliance-by-applications)
+  * [Example](#example)
+  * [Citing SigMF](#citing-sigmf)
+  * [Acknowledgements](#acknowledgements)
 
 ## Introduction
 
@@ -205,7 +205,7 @@ be namespaced.
 
 The format of the name/value pairs is:
 
-```
+```JSON
 "namespace:name": value,
 ```
 
@@ -271,11 +271,12 @@ namespaces may be defined by the user as needed.
    the canonical extension namespaces.
 
 ##### Canonical Extension Namespaces
+
 This is a list of the canonical extension namespaces defined by SigMF:
 
- * `antenna` - Used to describe the antenna(s) used to for the recording.
- * `modulation` - Defines how to describe modulations used in wireless communications systems.
- * `volatile` - Allows for continuously time-varying fields, such as a moving receiver or rotating antenna.
+* `antenna` - Used to describe the antenna(s) used to for the recording.
+* `capture_details` - Used to describe features of IQ captures and annotations.
+* `signal` - Used to describe modulated signals used in wireless communications systems.
 
 #### Global Object
 
@@ -304,7 +305,7 @@ the `global` object:
 |`hw`|false |string|A text description of the hardware used to make the recording.|
 |`geolocation`|false|GeoJSON `point` object|The location of the recording system.|
 |`hagl`|false|double|Antenna height above ground level (in meters).|
-|`extensions`|false|object|A list of extensions used by this recording.|
+|`extensions`|false|array|A list of objects describing extensions used by this recording.|
 
 ##### The `geolocation` Field
 The `core:geolocation` field in the `global` object is used to store the
@@ -328,20 +329,35 @@ example including the optional third altitude value is shown below:
 ```
 
 ##### The `extensions` Field
-The `core:extensions` field in the `global` object is JSON array of name/value
-pairs describing `SigMF Extension` namespaces, where the name is the namespace
-provided by an extension and the value is a string that specifies whether the
-extension is `optional` or the version of the extension required to properly
-parse & process the SigMF Recording. In the example below, `extension-01` is
-used, but not required, and `version 1.2.3` of `extension-02` *is* required.
+
+The `core:extensions` field in the `global` object is a JSON array of objects
+that describe SigMF extensions. These `extensions objects` have the following
+names defined in the `core` namespace:
+
+|name|required|type|description|
+|----|--------------|-------|-----------|
+|`name`|true|string|The name of the SigMF extension namespace.|
+|`version`|true|string|The version of the extension namespace specification used.|
+|`optional`|true|boolean|If this field is `true`, the extension is required to parse this recording.|
+
+In the example below, `extension-01` is used, but not required, and 
+`version 1.2.3` of `extension-02` *is* required.
 
 ```JSON
   "global": {
     ...
-    "core:extensions" : {
-      "extension-01": "optional",
-      "extension-02": "v1.2.3",
-    }
+    "core:extensions" : [
+        {
+        "name": "extension-01",
+        "version": "v0.0.5",
+        "optional": true
+        },
+        {
+        "name": "extension-02",
+        "version": "v1.2.3",
+        "optional": false
+        }
+    ]
     ...
   }
 ```


### PR DESCRIPTION
This branch makes the changes described in #103, including:
1. Move the extensions list to an actual JSON array
2. Break version out from optional.

I don't really care for the naming of the fields in the `extensions objects` at the moment. I first made them without the `ext_` prefix (e.g., `core:name`), but then decided against it as it creates a name conflict with `core:version` in the parent global object. I'd love to hear thoughts & feedback on this topic.

Note this PR also contains a few other issues to fix some MD linter warnings, which is a bit sloppy to wrap up in this branch - my apologies.