### PR TITLE
Require metadata to precede data member

### DIFF
--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -135,10 +135,11 @@ into a file archive. A `SigMF Archive` may contain multiple `SigMF Recordings`.
 3. The archive MUST contain the following files: for each contained recording
    with some name given here meta-syntactically as `N`, files named `N` (a
    directory), `N/N.sigmf-meta`, and `N/N.sigmf-data`.
-4. The archive MUST NOT contain any other files unless their pathnames begin
+4. The `N/N.sigmf-meta` MUST come before the `N/N.sigmf-data` member.
+5. The archive MUST NOT contain any other files unless their pathnames begin
    with `N/N`, for some `N` which has `.sigmf-meta` and `.sigmf-data` files as
    described above.
-5. It is RECOMMENDED that if recordings in an archive represent a continuous
+6. It is RECOMMENDED that if recordings in an archive represent a continuous
    dataset that has been split into separate recordings, that their filenames
    reflect the order of the series by appending a hyphenated zero-based index
    (e.g., `N-0`, `N-1`, `N-2`, etc.,).


### PR DESCRIPTION
Requiring the metadata to come before the data member allows you to process the archives data without actually unpacking it to the filesystem or copy all data into memory.

We take a similar approach (but with the older `ar` format not `tar`) in Debian, where the order must be the version member, the `control.tar.X` member, and finally the `data.tar.X` member.

This has no effect to any end-users who are manually unpacking the archives, nor any code which currently accepts any order of members, but it will mean new parsers that rely on this ordering will horck on existing archives. As such this is perhaps (if you squint just right) a breaking change in the spec, and I'm not sure how that is managed within this community. Feedback is very welcome.

Thanks for maintaining this spec!