### PR TITLE
Added ADS-B, Wi-Fi, capture_details, and RFML SigMF extensions.

### DIFF
--- a/extensions/adsb.sigmf-ext.md
+++ b/extensions/adsb.sigmf-ext.md
@@ -1,0 +1,19 @@
+# ADS-B Extension v1.0.0
+The Automatic Dependent Surveillance-Broadcast (`adsb`) namespace extension defines dynamic properties of ADS-B signals extending `annotations`.
+
+## Global
+The following names are specified in the `adsb` namespace and should be used in the `global` object:
+
+|name|required|type|unit|description|
+|----|--------------|-------|-------|-----------|
+|`version`|true|string|N/A|The version of the `adsb` extension used to create the metadata file.|
+
+## Annotations
+The following names are specified in the `adsb` namespace and should be used in the `annotations` object:
+
+|name|required|type|unit|description|
+|----|--------------|-------|-------|-----------|
+|`downlink_format`|true|int|N/A|Indicates if an ADS-B signal is a Mode S Short (11) or a Mode S Extended (17) signal.|
+|`message_type`|true|int|N/A|Indicates the type of data in a Mode S Extended signal.  The message type code range is from 0 to 31. The type of messages are aircraft identification (1-4), surface position (5-8), airborne position with barometric (9-18), airborne velocities (19), airborne position with GNSS (20-22), testing (23), reserved (24-27, 30), Emergency/Airborne Collision Avoidance System (ACAS) status (28), trajectory change (29), and aircraft operational status (31).  A signal with a Mode S Short downlink format does not contains a message and is represented by 0.
+|`ICA_address`|true|float|N/A|The International Civil Aviation Organization (ICAO) address of the ADS-B signal.|
+|`binary`|true|string|N/A|The binary signal, either 56 bits (Mode S Short) or 112 bits (Mode S Extended).|

--- a/extensions/capture_details.sigmf-ext.md
+++ b/extensions/capture_details.sigmf-ext.md
@@ -1,0 +1,33 @@
+# Capture Details Extension v1.0.0
+The `capture_details` namespace extension defines static IQ capture parameters extending `captures` and dynamic IQ capture parameters extending `annotations`.
+
+## Global
+
+The following names are specified in the `capture_details` namespace and should be used in the `global` object:
+
+|name|required|type|unit|description|
+|----|--------------|-------|-------|-----------|
+|`version`|true|string|N/A|The version of the `capture_details` extension used to create the metadata file.|
+
+## Captures
+
+The following names are specified in the `capture_details` namespace and should be used in the `captures` object:
+
+|name|required|type|unit|description|
+|----|--------------|-------|-------|-----------|
+|`acq_scale_factor`|true|float|N/A|Scale factor of IQ collection from the spectrum analyzer used to convert back to real power.|
+|`attentuation`|true|float|dB|Input attenuation on the spectrum analyzer.|
+|`acquisition_bandwidth`|true|float|Hz|Frequency range of the IQ recording.|
+|`start_capture`|true|string|N/A|Time of the first sample of IQ recording. The time is UTC with the format of `yyyy-mm-ddTHH:MM:SSZ`.|
+|`stop_capture`|true|string|N/A|Time of the last sample of IQ recording. The time is UTC with the format of `yyyy-mm-ddTHH:MM:SSZ`.|
+|`source_file`|true|string|N/A|RF IQ recording filename that was used to create the file `N.sigmf-data`.  The file `N.sigmf-data` may be the same or an edited versions of the `source_file`.|
+|`gain`|false|float|dB|Input gain.|
+
+## Annotations
+
+The following names are specified in the `capture_details` namespace and should be used in the `annotations` object:
+
+|name|required|type|unit|description|
+|----|--------------|-------|-------|-----------|
+|`SNRdB`|true|float|dB|Root mean square (RMS) calculation of signal to noise ratio (SNR). The calculation is over windows of known signal and no known signal.|
+|`signal_reference_number`|true|string|N/A|Sequential reference labels for the elements that form the sequence of signals identified in a SigMF dataset file. The format of the string is the filename followed by an index that increases with each decoded signal.  An example is a recording dataset file named `N.sigmf-data` would have signal numbers starting with `N-1`, `N-2`, `N-3`...|

--- a/extensions/rfml.sigmf-ext.md
+++ b/extensions/rfml.sigmf-ext.md
@@ -1,0 +1,20 @@
+# RFML Extension v1.0.0
+The radio frequency machine learning (`rfml`) namespace extension defines the protocol, manufacturer, and device labeling scheme for RF bursts.
+
+## Global
+
+The following names are specified in the `rfml` namespace and should be used in the `global` object:
+
+|name|required|type|unit|description|
+|----|--------------|-------|-------|-----------|
+|`label_hierarchy`|true|array|N/A|Defines hierarchy of the fields in the label array.|
+|`version`|true|string|N/A|The version of the `rfml` extension used to create the metadata file.|
+
+
+## Annotations
+
+The following names are specified in the `rfml` namespace and should be used in the `annotations` object:
+
+|name|required|type|unit|description|
+|----|--------------|-------|-------|-----------|
+|`label`|true|array|N/A|An array of hierarchical labels that describe this annotation. The label `device_type` is the type of RF transmitter or signal source.  The label `manufacturer_ID` is the manufacturer of the transmitter. The label `device_ID` is the source of the RF signal.|

--- a/extensions/wifi.sigmf-ext.md
+++ b/extensions/wifi.sigmf-ext.md
@@ -1,0 +1,33 @@
+## Wi-Fi Extension v1.0.0
+The `wifi`namespace extension defines dynamic Wi-Fi burst parameters extending `annotations`.
+
+## Global
+
+The following names are specified in the `wifi` namespace and should be used in the `global` object:
+
+|name|required|type|unit|description|
+|----|--------------|-------|-------|-----------|
+|`version`|true|string|N/A|The version of the `wifi` extension used to create the metadata file.|
+
+## Annotations
+
+The following names are specified in the `wifi` namespace and should be used in the `annotations` object:
+
+|name|required|type|unit|description|
+|----|--------------|-------|-------|-----------|
+|`standard`|true|string|N/A|Wireless standard of captured signal e.g. 802.11a/g.|
+|`frame_type_phy`|true|string|N/A|Physical layer specification e.g. non-high throughput or very-high throughput.|
+|`channel`|true|int|N/A|Wi-Fi channel of captured signal|
+|`start_time_s`|true|float|seconds|Start time of RF burst (relative time to start time of main capture file).|
+|`stop_time_s`|true|float|seconds|Stop time of RF burst (relative time to start time of main capture file).|
+|`frame_duration_s`|true|float|seconds|Duration of RF burst (`stop_time_s` –`start_time_s`).|
+|`MCS`|true|int|N/A|Wi-Fi signal Modulation and Coding Scheme (MCS).|
+|`MAC_frame_type`|true|string|N/A|Wi-Fi MAC frame type.|
+|`MAC_ta`|true|string|N/A|Wi-Fi transmitter MAC address.|
+|`MAC_ra`|true|string|N/A|Wi-Fi receiver MAC address.|
+|`manufacturer_ta`|true|string|N/A|Manufacturer of the Wi-Fi transmitter.|
+|`MAC_frame`|true|string|N/A|Wi-Fi MAC frame data without CRC.|
+|`CRC`|true|string|N/A|Wi-Fi MAC frame CRC.|
+|`start_of_packet`|true|float|samples|Starting sample of captured Wi-Fi burst.|
+|`stop_of_packet`|true|float|samples|Stopping sample of captured Wi-Fi burst.|
+|`number_of_samples_in_packet`|true|float|samples|Number of downsampled IQ samples in Wi-Fi burst.|


### PR DESCRIPTION
Four extensions to the SigMF standard:
- `adsb` defines dynamic properties of the Automatic Dependent Surveillance-Broadcast protocol.
- `wifi` defines dynamic properties of the Wi-Fi protocol.
- `capture_details` defines static and dynamic  IQ capture parameters.
- `rfml` defines a protocol, manufacturer, and device labeling scheme for machine learning on RF data.

These contributions are made on behalf of Naval Surface Warfare Center, Crane Division through their involvement with the DARPA Radio Frequency Machine Learning Systems (RFMLS) program.