### PR TITLE
Allow Freq (but not temporally) Bounded Annotations

### DIFF
--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -399,7 +399,7 @@ annotation segment objects:
 |name|required|type|description|
 |----|--------------|-------|-----------|
 |`sample_start`|true|uint|The sample index at which this segment takes effect.|
-|`sample_count`|true|uint|The number of samples that this segment applies to. |
+|`sample_count`|false|uint|The number of samples that this segment applies to. |
 |`generator`|false|string|Human-readable name of the entity that created this annotation.|
 |`comment`|false|string|A human-readable comment.|
 |`freq_lower_edge`|false|double|The frequency (Hz) of the lower edge of the feature described by this annotation.|
@@ -409,7 +409,9 @@ annotation segment objects:
 
 There is no limit to the number of annotations that can apply to the same group
 of samples. If two annotations have the same `sample_start`, there is no
-defined ordering between them.
+defined ordering between them. If `sample_count` is not provided, it should
+be assumed that the annotation applies from `sample_start` through the end of
+the dataset, in all other cases `sample_count` should be provided.
 
 The `freq_lower_edge` and `freq_upper_edge` fields should be at RF if the
 feature is at a known RF frequency. If there is no known center frequency (as


### PR DESCRIPTION
Previously `sample_count` was required, now it is optional to
allow defining spectrally (but not temporally) bounded sigmf
annotations.

Fixes #29 

Signed-off-by: Jacob Gilbert <jacob.gilbert@protonmail.com>