### PR TITLE
Explicit Scope for Captures Fields

### DIFF
--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -324,7 +324,9 @@ Capture segment objects are composed of name/value pairs.
 
 Each capture segment object must contain a `core:sample_start` name/value pair,
 which indicates the first index at which the rest of the segment's name/value
-pairs apply.
+pairs apply. The fields that are described within a `captures` segment are
+scoped to that segment only and must be declared again if they are valid in
+subsequent segments.
 
 The following names are specified in the `core` namespace and should be used in
 capture segment objects:


### PR DESCRIPTION
Per discussion in #124 this makes the scope of captures fields
explicitly defined partially resolving the issue.

Signed-off-by: Jacob Gilbert <jacob.gilbert@protonmail.com>