### PR TITLE
set pretty to true; important since it should be the default

### DIFF
--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -324,7 +324,7 @@ class SigMFFile(object):
         Parameters
         ----------
         filep : object
-            File pointer or something that json.dump() can handle
+            File pointer or something that json.dump() can handle.
         pretty : bool, optional
             Is true by default.
         '''
@@ -341,8 +341,6 @@ class SigMFFile(object):
 
         Parameters
         ----------
-        filep : object
-            File pointer or something that json.dump() can handle
         pretty : bool, optional
             Is true by default.
 
@@ -366,7 +364,7 @@ class SigMFFile(object):
         archive = SigMFArchive(self, name, fileobj)
         return archive.path
 
-    def tofile(self, file_path, pretty=False, toarchive=False):
+    def tofile(self, file_path, pretty=True, toarchive=False):
         """
         Dump contents to file.
         """


### PR DESCRIPTION
The following squashed commit was approved for public release by The Aerospace Corporation on 2020-06-17. It is covered software release request #SW19-0024. Commits made by the Communications Software Implementation Department.

### Fixes
This tiny PR resolves an oversight made during our last commit by setting the default `tofile()` method to set the default keyword `pretty=true` which saves `sigmf-meta` files with indented & sorted keys instead of a long string.