### PR TITLE
Feature/optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,14 +3,14 @@ from setuptools import setup
 import os
 import re
 
-shortdesc = "Signal Metadata Format Specification"
-longdesc = """
+shortdesc = 'Signal Metadata Format Specification'
+longdesc = '''
 The Signal Metadata Format (SigMF) specifies a way to describe
 sets of recorded digital signal samples with metadata written in JSON.
 SigMF can be used to describe general information about a collection
 of samples, the characteristics of the system that generated the
 samples, and features of the signal itself.
-"""
+'''
 
 with open(os.path.join('sigmf', '__init__.py')) as handle:
     version = re.search(r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]', handle.read()).group(1)
@@ -29,17 +29,17 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
-    entry_points = {
+    entry_points={
         'console_scripts': ['sigmf_validate=sigmf.validate:main']
     },
     packages=['sigmf'],
-    package_data = {
+    package_data={
         'sigmf': ['*.json'],
     },
-    install_requires=[
-        'numpy',
-        'pysimplegui==4.0.0'
-    ],
+    install_requires=['numpy'],
+    extras_require={
+        'gui': 'pysimplegui==4.0.0'
+    },
     setup_requires=['pytest-runner'],
     tests_require=['pytest>3'],
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,10 @@ setup(
         'Programming Language :: Python :: 3.8',
     ],
     entry_points={
-        'console_scripts': ['sigmf_validate=sigmf.validate:main']
+        'console_scripts': [
+            'sigmf_validate = sigmf.validate:main',
+            'sigmf_gui = sigmf.gui:main [gui]',
+        ]
     },
     packages=['sigmf'],
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,10 @@ setup(
     package_data = {
         'sigmf': ['*.json'],
     },
-    install_requires=['six', 'numpy', 'pysimplegui==4.0.0'],
+    install_requires=[
+        'numpy',
+        'pysimplegui==4.0.0'
+    ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest>3'],
     zip_safe=False

--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2016 GNU Radio Foundation
+# Copyright 2021 GNU Radio Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/sigmf/archive.py
+++ b/sigmf/archive.py
@@ -1,4 +1,4 @@
-# Copyright 2017 GNU Radio Foundation
+# Copyright 2021 GNU Radio Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/sigmf/error.py
+++ b/sigmf/error.py
@@ -1,4 +1,4 @@
-# Copyright 2017 GNU Radio Foundation
+# Copyright 2021 GNU Radio Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/sigmf/gui.py
+++ b/sigmf/gui.py
@@ -20,9 +20,9 @@
 
 '''GUI for creating & editing SigMF Files'''
 
-from PySimpleGUI import *
 import os
 import logging
+from PySimpleGUI import *
 
 from .sigmffile import SigMFFile, fromarchive, dtype_info
 from .archive import SIGMF_ARCHIVE_EXT
@@ -44,8 +44,7 @@ class Unit:
     def convert(unit, value: float):
         if unit is None:
             return input
-
-        if unit == Unit.MHZ:
+        elif unit == Unit.MHZ:
             return value * 1e6
         elif unit == Unit.US:
             return value * 1e-6
@@ -119,36 +118,57 @@ class WindowInput(WindowElementGroup):
         ANTEN_POL = 'Antenna Polarization'
         ANTEN_GAIN = 'Antenna Gain'
 
-        self.core_element_list = [WindowInput.DATA_TYPE_COMPLEX, WindowInput.DATA_TYPE_UNSIGNED,
-                                  WindowInput.DATA_TYPE_FIXEDPOINT, WindowInput.DATA_SAMPLE_SIZE,
-                                  WindowInput.DATA_BYTE_ORDER, DATA_OFFSET, DESCRIPTION, AUTHOR, DATE, SAMPLING_RATE]
+        self.core_element_list = [
+            WindowInput.DATA_TYPE_COMPLEX,
+            WindowInput.DATA_TYPE_UNSIGNED,
+            WindowInput.DATA_TYPE_FIXEDPOINT,
+            WindowInput.DATA_SAMPLE_SIZE,
+            WindowInput.DATA_BYTE_ORDER,
+            DATA_OFFSET, DESCRIPTION, AUTHOR, DATE, SAMPLING_RATE,
+        ]
         self.secondary_element_list = [HARDWARE, NORM_TECH, RECEIVER_LAT, ANTEN_POL, RECEIVER_LON, ANTEN_GAIN]
         self.file_element_list = [WindowInput.DATA_FILE, WindowInput.OUTPUT_FOLDER]
-        self.partial_component_list = [WindowInput.DATA_TYPE_COMPLEX, WindowInput.DATA_TYPE_UNSIGNED,
-                                       WindowInput.DATA_TYPE_FIXEDPOINT, WindowInput.DATA_SAMPLE_SIZE,
-                                       WindowInput.DATA_BYTE_ORDER]
+        self.partial_component_list = [
+            WindowInput.DATA_TYPE_COMPLEX,
+            WindowInput.DATA_TYPE_UNSIGNED,
+            WindowInput.DATA_TYPE_FIXEDPOINT,
+            WindowInput.DATA_SAMPLE_SIZE,
+            WindowInput.DATA_BYTE_ORDER,
+        ]
         sigmf_tags = {
             DESCRIPTION: SigMFFile.DESCRIPTION_KEY,
             SAMPLING_RATE: SigMFFile.SAMPLE_RATE_KEY,
-            AUTHOR: SigMFFile.AUTHOR_KEY, DATE: SigMFFile.DATETIME_KEY, HARDWARE: SigMFFile.HW_KEY,
+            AUTHOR: SigMFFile.AUTHOR_KEY,
+            DATE: SigMFFile.DATETIME_KEY,
+            HARDWARE: SigMFFile.HW_KEY,
             RECEIVER_LAT: SigMFFile.LAT_KEY,
-            RECEIVER_LON: SigMFFile.LON_KEY}
+            RECEIVER_LON: SigMFFile.LON_KEY,
+        }
         req_tags = [WindowInput.DATA_FILE, WindowInput.DATA_SAMPLE_SIZE, WindowInput.DATA_BYTE_ORDER, SAMPLING_RATE]
-        el_types = {WindowInput.DATA_TYPE_COMPLEX: bool, WindowInput.DATA_TYPE_UNSIGNED: bool,
-                    WindowInput.DATA_TYPE_FIXEDPOINT: bool, DATA_OFFSET: int, RECEIVER_LAT: float,
-                    RECEIVER_LON: float, ANTEN_GAIN: float, SAMPLING_RATE: float}
+        el_types = {
+            WindowInput.DATA_TYPE_COMPLEX: bool,
+            WindowInput.DATA_TYPE_UNSIGNED: bool,
+            WindowInput.DATA_TYPE_FIXEDPOINT: bool,
+            DATA_OFFSET: int, RECEIVER_LAT: float,
+            RECEIVER_LON: float, ANTEN_GAIN: float, SAMPLING_RATE: float,
+        }
         el_units = {ANTEN_GAIN: Unit.DBI}
-        el_tooltip = {DATE: 'YYYY-MM-DD',
-                      DATA_OFFSET: 'int: bit offset from start of data file of first element'}
+        el_tooltip = {
+            DATE: 'YYYY-MM-DD',
+            DATA_OFFSET: 'int: bit offset from start of data file of first element'}
         el_text = {}
         el_help = {WindowInput.DATA_BYTE_ORDER: 'Data Type Help'}
         el_multiline = [DESCRIPTION]
         el_selector = {WindowInput.DATA_SAMPLE_SIZE: [8, 16, 32],
                        WindowInput.DATA_BYTE_ORDER: ['little endian', 'big endian']}
         el_checkbox = [WindowInput.DATA_TYPE_COMPLEX, WindowInput.DATA_TYPE_UNSIGNED, WindowInput.DATA_TYPE_FIXEDPOINT]
-        el_size = {WindowInput.DATA_TYPE_COMPLEX: (3, 1), WindowInput.DATA_TYPE_UNSIGNED: (3, 1),
-                   WindowInput.DATA_TYPE_FIXEDPOINT: (3, 1), WindowInput.DATA_SAMPLE_SIZE: (4, 1),
-                   WindowInput.DATA_BYTE_ORDER: (15, 1)}
+        el_size = {
+            WindowInput.DATA_TYPE_COMPLEX: (3, 1),
+            WindowInput.DATA_TYPE_UNSIGNED: (3, 1),
+            WindowInput.DATA_TYPE_FIXEDPOINT: (3, 1),
+            WindowInput.DATA_SAMPLE_SIZE: (4, 1),
+            WindowInput.DATA_BYTE_ORDER: (15, 1),
+        }
         self.first_line_size = 5
         super().__init__(self.core_element_list + self.secondary_element_list, sigmf_tags, req_tags, el_types, el_units,
                          el_tooltip, el_text, el_help, el_multiline, el_selector, el_checkbox, el_size)
@@ -196,13 +216,16 @@ class CaptureData(WindowElementGroup):
                         MODULATION, PRF, STAGGER, FREQUENCY_HOPPING, PW, BEAM_PATTERN, SNR,
                         CHIP_RATE] + self.annotation_element_list
         sigmf_tags = {
-            CaptureData.START_INDEX: SigMFFile.START_INDEX_KEY, 
+            CaptureData.START_INDEX: SigMFFile.START_INDEX_KEY,
             RECEIVER_RF: SigMFFile.FREQUENCY_KEY,
             COMMENT: SigMFFile.COMMENT_KEY
         }
         req_tags = [CaptureData.START_INDEX]
-        el_types = {CaptureData.START_INDEX: int, RECEIVER_RF: float, SIGNAL_BANDWIDTH: float,
-                    PRF: float, PW: float, SNR: float, CHIP_RATE: float}
+        el_types = {
+            CaptureData.START_INDEX: int,
+            RECEIVER_RF: float, SIGNAL_BANDWIDTH: float,
+            PRF: float, PW: float, SNR: float, CHIP_RATE: float,
+        }
         el_units = {PW: Unit.US, SIGNAL_BANDWIDTH: Unit.MHZ, RECEIVER_RF: Unit.MHZ}
         el_tooltip = {CaptureData.START_INDEX: 'int: start index in file of capture'}
         el_text = {}
@@ -242,7 +265,7 @@ def add_sigmf_field(funct, values, field_name, *args, required=False, type=None,
                 return False
         elif type == bool:
             try:
-                if input != 'False' and input != 'True':
+                if input not in ['False', 'True']:
                     raise ValueError('Unexpected input for boolean')
                 input = True if input == 'True' else False
             except ValueError:
@@ -314,7 +337,7 @@ def update_global_screen(window_data_input, window_text_blocks, window_dict, arc
 
 
 def add_capture(capture_data_input, values, capture_selector_dict, file_data, from_archive=False):
-    capture_dict = dict()
+    capture_dict = {}
     added = True
     for el in capture_data_input.iter():
         req_field = True if el in capture_data_input.req_tags else False
@@ -372,19 +395,26 @@ def add_capture(capture_data_input, values, capture_selector_dict, file_data, fr
 
 
 def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Edit SigMF Archive.')
+    parser.add_argument('-i', '--input', help='Input SigMF Archive Path.', default=None)
+    parser.add_argument('-v', '--verbose', action='count', default=0)
+    args = parser.parse_args()
+
     level_lut = {
         0: logging.WARNING,
         1: logging.INFO,
         2: logging.DEBUG,
     }
-    logging.basicConfig(level=level_lut[2])
+    logging.basicConfig(level=level_lut[min(args.verbose, 2)])
 
     window_input = WindowInput()
     capture_data_input = CaptureData()
-    capture_text_blocks = dict()
-    window_text_blocks = dict()
+    capture_text_blocks = {}
+    window_text_blocks = {}
     f = SigMFFile()
-    capture_selector_dict = dict()
+    capture_selector_dict = {}
 
     layout = [[Text('This is the SigMF tool to archive RF datasets', size=(80, 1))],
               [Text('Enter your data and signal captures below. You must include', auto_size_text=True),
@@ -481,6 +511,17 @@ def main():
                     default_button_element_size=(10, 1)
                     ).Layout(layout)
 
+    if args.input:
+        window.Refresh()
+        # optional input file specified -> load
+        log.info(f'reading from {args.input}')
+        load_path = args.input
+        f = fromarchive(load_path)
+        update_global_screen(window_input, window_text_blocks, f.get_global_info(), f)
+        capture_selector_dict = {}
+        for capture in f.get_captures():
+            add_capture(capture_data_input, capture, capture_selector_dict, f, from_archive=True)
+
     while True:
         validate_button.Update(text='Update')
         load_button.Update(text='Load')
@@ -545,10 +586,8 @@ def main():
             data_type_str += str(window_data_type_dict[WindowInput.DATA_SAMPLE_SIZE]) + '_'
             data_type_str += 'le' if window_data_type_dict[WindowInput.DATA_BYTE_ORDER] == 'little endian' else 'be'
             data_type_dict = {SigMFFile.DATATYPE_KEY: data_type_str}
-            added = added and add_sigmf_field(SigMFFile.set_global_field, data_type_dict, SigMFFile.DATATYPE_KEY, f,
-                                              SigMFFile.DATATYPE_KEY, required=True)
-            added = added and add_sigmf_field(SigMFFile.set_data_file, values, WindowInput.DATA_FILE, f,
-                                              required=True) and added
+            added = added and add_sigmf_field(SigMFFile.set_global_field, data_type_dict, SigMFFile.DATATYPE_KEY, f, SigMFFile.DATATYPE_KEY, required=True)
+            added = added and add_sigmf_field(SigMFFile.set_data_file, values, WindowInput.DATA_FILE, f, required=True) and added
             if not added:
                 # requirement not given
                 continue
@@ -562,7 +601,7 @@ def main():
             add_capture(capture_data_input, values, capture_selector_dict, f)
 
         elif event == 'Remove Capture':
-            capture_dict = dict()
+            capture_dict = {}
             added = add_sigmf_field(update_dictionary, values, CaptureData.START_INDEX, capture_dict,
                                     SigMFFile.START_INDEX_KEY, required=True, type=int)
             if not added:
@@ -599,7 +638,7 @@ def main():
             if output_folder == '':
                 show_error('No output folder provided')
                 continue
-            elif len(capture_selector_dict.keys()) == 0:
+            if len(capture_selector_dict.keys()) == 0:
                 show_error('No capture data specified')
             submit_button.Update(text='Saving...')
             window.Refresh()

--- a/sigmf/gui.py
+++ b/sigmf/gui.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-# Copyright 2020 The Johns Hopkins University Applied Physics Laboratory LLC.  All Rights Reserved.
+# Copyright 2021 GNU Radio Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -8,8 +7,8 @@
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
 #
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -19,11 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+'''GUI for creating & editing SigMF Files'''
+
 from PySimpleGUI import *
-from sigmf.sigmffile import SigMFFile, fromarchive, dtype_info
-from sigmf.archive import SIGMF_ARCHIVE_EXT
 import os
 import warnings
+
+from .sigmffile import SigMFFile, fromarchive, dtype_info
+from .archive import SIGMF_ARCHIVE_EXT
 
 warnings.filterwarnings("error")
 
@@ -227,13 +229,13 @@ def add_sigmf_field(funct, values, field_name, *args, required=False, type=None,
                 return False
             try:
                 input = int(input)
-            except:
+            except ValueError:
                 show_error('Expected an integer for: {}'.format(field_name))
                 return False
         elif type == float:
             try:
                 input = float(input)
-            except:
+            except ValueError:
                 show_error('Expected a double for: {}'.format(field_name))
                 return False
         elif type == bool:
@@ -241,7 +243,7 @@ def add_sigmf_field(funct, values, field_name, *args, required=False, type=None,
                 if input != 'False' and input != 'True':
                     raise ValueError('Unexpected input for boolean')
                 input = True if input == 'True' else False
-            except:
+            except ValueError:
                 show_error('Expected a bool for: {}'.format(field_name))
                 return False
         Unit.convert(unit, input)
@@ -251,7 +253,7 @@ def add_sigmf_field(funct, values, field_name, *args, required=False, type=None,
             else:
                 funct(*args, input)
         except UserWarning as w:
-            Popup('Warning: '.format(repr(w)), title='Warning')
+            Popup('Warning: {}'.format(repr(w)), title='Warning')
         except Exception as e:
             show_error(repr(e))
             return False
@@ -367,7 +369,7 @@ def add_capture(capture_data_input, values, capture_selector_dict, file_data, fr
         combo_button.Update(values=tuple(new_values), value=new_val)
 
 
-def run_gui():
+def main():
     window_input = WindowInput()
     capture_data_input = CaptureData()
     capture_text_blocks = dict()
@@ -375,7 +377,7 @@ def run_gui():
     f = SigMFFile()
     capture_selector_dict = dict()
 
-    layout = [[Text('This is the APL SIGMF tool to archive RF datasets', size=(80, 1))],
+    layout = [[Text('This is the SigMF tool to archive RF datasets', size=(80, 1))],
               [Text('Enter your data and signal captures below. You must include', auto_size_text=True),
                Text('required', text_color='red', font=DEFAULT_FONT + ('italic',), auto_size_text=True),
                Text('fields.', size=(50, 1), auto_size_text=True)],
@@ -463,7 +465,7 @@ def run_gui():
          [validate_button, Button('View Data')]]
     )
 
-    window = Window('APL SigMF Archive Creator',
+    window = Window('SigMF Archive Creator',
                     auto_size_buttons=False,
                     default_element_size=(20, 1),
                     auto_size_text=False,
@@ -601,7 +603,3 @@ def run_gui():
             break
 
     window.Close()
-
-
-if __name__ == '__main__':
-    run_gui()

--- a/sigmf/schema.py
+++ b/sigmf/schema.py
@@ -1,4 +1,4 @@
-# Copyright 2016 GNU Radio Foundation
+# Copyright 2021 GNU Radio Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,8 +27,15 @@ from . import utils
 
 
 def get_schema(version=None):
+    '''
+    safe load json
+
+    In the future load specific schema versions.
+    '''
     schema_file = os.path.join(
         utils.get_schema_path(os.path.dirname(utils.__file__)),
         'schema.json'
     )
-    return json.load(open(schema_file))
+    with open(schema_file, 'rb') as handle:
+        schema = json.load(handle)
+    return schema

--- a/sigmf/sigmf_hash.py
+++ b/sigmf/sigmf_hash.py
@@ -1,4 +1,4 @@
-# Copyright 2016 GNU Radio Foundation
+# Copyright 2021 GNU Radio Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -27,7 +27,6 @@ import tarfile
 import tempfile
 from os import path
 import warnings
-from six import iteritems
 import numpy as np
 
 from . import __version__, schema, sigmf_hash, validate
@@ -119,7 +118,7 @@ class SigMFFile():
         Throws if not.
         """
         schema_section = self.get_schema()[section_key]
-        for key, value in iteritems(entries):
+        for key, value in entries.items():
             validate.validate_key_throw(
                 value, schema_section.get(key, {}), schema_section, key
             )
@@ -616,7 +615,7 @@ def get_default_metadata(schema):
         " Return a dict with all default values from keys_dict "
         return {
             key: desc.get("default")
-            for key, desc in iteritems(keys_dict)
+            for key, desc in keys_dict.items()
             if "default" in desc
         }
 
@@ -629,5 +628,5 @@ def get_default_metadata(schema):
 
     return {
         category: default_category_data(desc["type"], get_default_dict(desc["keys"]))
-        for category, desc in iteritems(schema)
+        for category, desc in schema.items()
     }

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -1,4 +1,4 @@
-# Copyright 2016 GNU Radio Foundation
+# Copyright 2021 GNU Radio Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/sigmf/utils.py
+++ b/sigmf/utils.py
@@ -23,9 +23,6 @@
 from copy import deepcopy
 from datetime import datetime
 
-from six import iteritems
-
-
 SIGMF_DATETIME_ISO8601_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
@@ -44,12 +41,13 @@ def dict_merge(a_dict, b_dict):
     if not isinstance(b_dict, dict):
         return b_dict
     result = deepcopy(a_dict)
-    for key, value in iteritems(b_dict):
+    for key, value in b_dict.items():
         if key in result and isinstance(result[key], dict):
             result[key] = dict_merge(result[key], value)
         else:
             result[key] = deepcopy(value)
     return result
+
 
 def insert_sorted_dict_list(dict_list, new_entry, key, force_insertion=False):
     """
@@ -69,6 +67,7 @@ def insert_sorted_dict_list(dict_list, new_entry, key, force_insertion=False):
             return dict_list
     dict_list = dict_list + [new_entry]
     return dict_list
+
 
 def get_schema_path(module_path):
     """

--- a/sigmf/utils.py
+++ b/sigmf/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2016 GNU Radio Foundation
+# Copyright 2021 GNU Radio Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/sigmf/validate.py
+++ b/sigmf/validate.py
@@ -1,4 +1,4 @@
-# Copyright 2016 GNU Radio Foundation
+# Copyright 2021 GNU Radio Foundation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
@bhilburn Closes #149 

## Features
* Adds `sigmf_gui` as entry_point to launch the archive editor
* Moved `pysimplegui` to optional dependency in `setup.py`.
* Switched printing to logging in gui
* Added argument parsing for `sigmf_gui`
* Fixed several bugs preventing gui from loading / saving with current SigMF spec

## Todo
* Fields in gui should be generated automatically from the schema, not as defined in `gui.py`. Consider adding to v1.1 release.
* gui should be able to load sigmf pairs. Currently only loads archives. Consider adding to v1.1 release.
* When loading archive from command line, some checkbox errors are generated - but it doesn't seem to be a problem.
* Once we are happy with the gui operation, an example should be created in the `README.md`. Add to v1.1 tasks.

![image](https://user-images.githubusercontent.com/784749/131078055-05bb93d0-0d00-4170-a17b-a7d8e91d0986.png)


