### PR TITLE
geolocation: fix lon/lat inversion

### DIFF
--- a/extensions/signal.sigmf-ext.md
+++ b/extensions/signal.sigmf-ext.md
@@ -269,7 +269,7 @@ An example describing just the ID, power, and location of an emitter:
             "power_eirp": 43.0,
             "geolocation": {
                 "type": "point",
-                "coordinates": [38.8984531, -77.0729078]
+                "coordinates": [-77.071651, 38.897397]
             }
         }
     }]

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -312,7 +312,7 @@ location of the recording system. The location is stored as a single
 [RFC 7946](https://www.rfc-editor.org/rfc/rfc7946.txt) GeoJSON `point` object
 using the convention defined by [RFC 5870](https://www.rfc-editor.org/rfc/rfc5870.txt).
 Per the GeoJSON specification, the point coordinates use the WGS84 coordinate
-reference system and are `latitude`, `longitude` (required, in decimal degrees),
+reference system and are `longitude`, `latitude` (required, in decimal degrees),
 and `altitude` (optional, in meters above the WGS84 ellipsoid) in that order. An
 example including the optional third altitude value is shown below:
 
@@ -321,7 +321,7 @@ example including the optional third altitude value is shown below:
     ...
     "core:geolocation": {
       "type": "Point",
-      "coordinates": [34.0787916, -107.6183682, 2120.0]
+      "coordinates": [-107.6183682, 34.0787916, 2120.0]
     }
     ...
   }

--- a/sigmf/schema.json
+++ b/sigmf/schema.json
@@ -84,7 +84,7 @@
                     "coordinates": {
                         "type": "double_list",
                         "required": true,
-                        "help": "Latitude (deg), longitude (deg), and optional altitude (m) per RFC 5870"
+                        "help": "Longitude (deg), latitude (deg), and optional altitude (m) per RFC 5870"
                     }
                 }
             },


### PR DESCRIPTION
This is a significant oversight in how the GeoJSON spec is implemented, which require longitude first.

https://www.rfc-editor.org/rfc/rfc7946.txt see: [Page 12]