### PR TITLE
i16 is not a legal type

### DIFF
--- a/logo/sigmf_logo.sigmf-meta
+++ b/logo/sigmf_logo.sigmf-meta
@@ -1,7 +1,7 @@
 {
     "global": {
         "core:author": "Kyle Logue, K6OF",
-        "core:datatype": "i16_le",
+        "core:datatype": "ri16_le",
         "core:description": "The Official SigMF Logo",
         "core:license": "https://creativecommons.org/licenses/by-sa/4.0/",
         "core:num_channels": 2,

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -203,7 +203,7 @@ Complex samples should be interleaved, with the in-phase component first (i.e.,
 Global object (described below) indicates that the Recording contains more than one channel,
 samples from those channels should be interleaved in the same manner, with
 the same index from each channel's sample serially in the recording. For
-example, a Recording with two channels of `i16_le` representing real-valued
+example, a Recording with two channels of `ri16_le` representing real-valued
 audio data from a stereo recording and here labeled `L` for left and `R` for
 right, the data should appear as `L[0]` `R[0]` `L[1]` `R[1]` ... `L[n]` `R[n]`.
 The data type specified by `core:data_type` applies to all channels of data


### PR DESCRIPTION
replace with ri16 in the spec example and in the logo sigmf-meta file.

Closes #172 