### PR TITLE
move HAGL field to antenna extension

### DIFF
--- a/extensions/antenna.sigmf-ext.md
+++ b/extensions/antenna.sigmf-ext.md
@@ -26,6 +26,7 @@ The following names are specified in the `antenna` namespace and should be used 
 |`cable_loss`|false|float|dB|Cable loss for cable connecting antenna and preselector.|
 |`steerable`|false|boolean|N/A|Defines if the antenna is steerable or not.|
 |`mobile`|false|boolean|N/A|Defines if the antenna is mobile or not.|
+|`hagl`|false|double|meters|Antenna phase center height above ground level.|
 
 ## 2 Captures
 
@@ -49,6 +50,7 @@ The following fields are specificed in SigMF Collections.
 |----|--------------|-------|-------|-----------|
 |`azimuth_angle`|false|float|degrees|Angle of main beam in azimuthal plane from North.|
 |`elevation_angle`|false|float|degrees|Angle of main beam in elevation plane from horizontal.|
+|`hagl`|false|SigMF Recording Tuple|Antenna height above ground level (in meters).|
 
 ## 5 Examples
 

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -311,7 +311,6 @@ the Global object:
 | `license`      | false    | string  | A URL for the license document under which the Recording is offered.|
 | `hw`           | false    | string  | A text description of the hardware used to make the Recording.|
 | `geolocation`  | false    | GeoJSON `point` object | The location of the Recording system.|
-| `hagl`         | false    | double  | Antenna height above ground level (in meters).|
 | `extensions`   | false    | array   | A list of JSON Objects describing extensions used by this Recording.|
 | `collection`   | false    | string  | The base filename of a `collection` with which this Recording is associated.|
 
@@ -521,7 +520,6 @@ The following names are specified in the `core` namespace for use in the `collec
 | `author`         | false    | string                | The author's name (and optionally e-mail address) of the form "Bruce Wayne <wayne@example.com>".|
 | `collection_doi` | false    | string                | The registered DOI (ISO 26324) for a Collection.|
 | `license`        | false    | string                | A URL for the license document under which this Collection metadata is offered.|
-| `hagl`           | false    | SigMF Recording Tuple | Antenna height above ground level (in meters).|
 | `extensions`     | false    | array                 | A list of objects describing extensions used by this Collection.|
 | `streams`        | false    | array                 | An ordered array of SigMF Recording Tuples, indicating multiple recorded streams of data (e.g., phased array collections).|
 
@@ -539,7 +537,7 @@ Example `top-level.sigmf-collection` file:
             }
          ],
 
-        "core:hagl": ["hagl-basename", "hash"],
+        "antenna:hagl": ["hagl-basename", "hash"],
 
         "antenna:azimuth_angle": ["azimuth-angle-basename", "hash"],
 

--- a/sigmf/schema.json
+++ b/sigmf/schema.json
@@ -88,11 +88,6 @@
                     }
                 }
             },
-            "core:hagl": {
-                "type": "double",
-                "required": false,
-                "help": "Antenna height above ground level (in meters)."
-            },
             "core:extensions": {
                 "required": false,
                 "help": "A list of extensions used by this recording.",
@@ -226,11 +221,6 @@
                 "type": "string",
                 "required": false,
                 "help": "A URL for the license document under which the collection is offered; when possible, use the canonical document provided by the license author, or, failing that, a well-known one."
-            },
-            "core:hagl": {
-                "type": "list",
-                "required": false,
-                "help": "Recording Tuple pointing to a F32 type dataset representing aperture HAGL."
             },
             "core:extensions": {
                 "required": false,


### PR DESCRIPTION
Per discussion on matrix.

This also fixes two missing-comma schema bugs.