### PR TITLE
allow annotations greater than _or equal_ to 1

### DIFF
--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -217,7 +217,7 @@ class SigMFFile():
         Insert annotation
         """
         assert start_index >= self._get_start_offset()
-        assert length > 1
+        assert length >= 1
         metadata = metadata or {}
         metadata[self.START_INDEX_KEY] = start_index
         metadata[self.LENGTH_INDEX_KEY] = length


### PR DESCRIPTION
I do not see a reason we should prohibit length 1 annotations.