### PR TITLE
added utility function to automate data type str generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ for adx, annotation in enumerate(annotations):
 ```python
 import datetime as dt
 from sigmf import SigMFFile
+from sigmf.utils import get_data_type_str
 
 # suppose we have an complex timeseries signal
 data = np.zeros(1024, dtype=np.complex64)
@@ -119,7 +120,7 @@ data.tofile('example.sigmf-data')
 meta = SigMFFile(
     data_file='example.sigmf-data', # extension is optional
     global_info = {
-        SigMFFile.DATATYPE_KEY: 'cf32_le',
+        SigMFFile.DATATYPE_KEY: get_data_type_str(data),  # in this case, 'cf32_le'
         SigMFFile.SAMPLE_RATE_KEY: 48000,
         SigMFFile.AUTHOR_KEY: 'jane.doe@domain.org',
         SigMFFile.DESCRIPTION_KEY: 'All zero example file.',


### PR DESCRIPTION
The get_endian_str() function is separate to support my own hack
for generating the string for complex int16 data ...

    >>> sigmf.utils.get_data_type_str(numpy.zeros(1, dtype=float))
    'f64_le'
    >>> sigmf.utils.get_data_type_str(numpy.zeros(1, dtype=complex))
    'cf128_le'
    >>> sigmf.utils.get_data_type_str(numpy.zeros(1, dtype=numpy.uint32))
    'u32_le'
    >>> sigmf.utils.get_data_type_str(numpy.zeros(1, dtype=numpy.uint16))
    'u16_le'
    >>> sigmf.utils.get_data_type_str(numpy.zeros(1, dtype=numpy.complex64))
    'cf64_le'
    >>> sigmf.utils.get_data_type_str(numpy.zeros(1, dtype='>f4'))
    'f32_be'
    >>> sigmf.utils.get_data_type_str(numpy.zeros(1, dtype='=f4'))
    'f32_le'
    >>> sigmf.utils.get_data_type_str(numpy.zeros(1, dtype='<f4'))
    'f32_le'
    >>> sigmf.utils.get_data_type_str(numpy.zeros(1, dtype='<c8'))
    'cf64_le'
    >>> sigmf.utils.get_data_type_str(numpy.zeros(1, dtype='?'))
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/s/sigmf/utils.py", line 98, in get_data_type_str
        raise error.SigMFError('Unsupported data type:', atype)
    sigmf.error.SigMFError: ('Unsupported data type:', dtype('bool'))