### PR TITLE
Fix for dataset filenames containing periods

### DIFF
--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -630,9 +630,11 @@ def get_sigmf_filenames(filename):
     Returned as dict with 'data_fn', 'meta_fn', and 'archive_fn' as keys.
 
     Keyword arguments:
-    filename -- the SigMF filename
+    filename -- the SigMF dataset filename (with or without .sigmf* extension)
     """
-    filename = path.splitext(filename)[0]
+    filename_lower = filename.lower()
+    if filename_lower.endswith(SIGMF_DATASET_EXT) or filename_lower.endswith(SIGMF_METADATA_EXT) or filename_lower.endswith(SIGMF_ARCHIVE_EXT):
+        filename = path.splitext(filename)[0]
     return {'data_fn': filename+SIGMF_DATASET_EXT, 'meta_fn': filename+SIGMF_METADATA_EXT, 'archive_fn': filename+SIGMF_ARCHIVE_EXT}
 
 


### PR DESCRIPTION
This PR addresses a bug that causes filenames containing periods (other than the delimiter between the base filename and extension) to be handled incorrectly when loading or saving datasets.

The issue is due to the way `sigmffile.get_sigmf_filenames()` attempts to remove extensions from filenames, which is done to make inclusion of SigMF filename extensions optional for the user. The proposed fix is to treat anything other than valid SigMF filename extensions (`.sigmf-meta`, `.sigmf-data`, or `.sigmf`) as part of the filename when using `get_sigmf_filenames()`.

Fixes #194 .