### PR TITLE
captures metadata does not carry forward

### DIFF
--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -231,7 +231,7 @@ class SigMFFile():
         for capture in captures:
             if capture[self.START_INDEX_KEY] > index:
                 break
-            cap_info = dict_merge(cap_info, capture)
+            cap_info = capture
         return cap_info
 
     def add_annotation(self, start_index, length, metadata=None):


### PR DESCRIPTION
Per our specification:

```
The fields that are described within a Capture Segment are scoped to that Segment only and need to be explicitly declared again if they are valid in subsequent Segments.
```

Thus, captures data must be explicitly redeclared and does not implicitly carry forward in the absence of a new value.