### PR TITLE
SigMFFile class is now an iterable for accessing data via memmap

### DIFF
--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__version__ = '1.0.2'
+__version__ = '1.0.1'
 
 from .archive import SigMFArchive
 from .sigmffile import SigMFFile


### PR DESCRIPTION
It also now has .ndim and .shape members and has a __getitem__() method.

The purpose in this patch is to better facilitate the accessing of very large data sets through the use of `numpy.memmap()`.  The complications arise when handling types supported by SigMF but not by numpy, like fixed-precision complex samples.  The proposed solution still provides access to the data on disk through the use of `._memmap` (expert mode) but when using the bracket operator, useful datatypes are always returned.

I would like to think that this new approach could someday make the `readsamples()` method (in its current form) obsolete, but that's premature even if it were the right thing to do

Test with this code:
```python
#!/usr/bin/env python3

import json
import numpy
import sigmf
import warnings

warnings.filterwarnings("always")

meta = {
    "global": {
        "core:author": "Glen M",
        "core:datatype": "ri16_le",
        "core:license": "https://creativecommons.org/licenses/by-sa/4.0/",
        "core:num_channels": 2,
        "core:sample_rate": 48000,
        "core:version": "1.0.0"
    },
    "captures": [
        {
            "core:datetime": "2021-06-18T23:17:51.163959Z",
            "core:sample_start": 0
        }
    ] }

NUM_ROWS = 5

for dt in "ri16_le", "ci16_le", "rf32_le", "rf64_le", "cf32_le", "cf64_le":
    meta["global"]["core:datatype"] = dt
    for num_chan in 1,3:
        meta["global"]["core:num_channels"] = num_chan
        base_filename = dt + '_' + str(num_chan)
        meta_filename = base_filename + '.sigmf-meta'
        meta_fid = open(meta_filename, 'w')
        json.dump(meta, meta_fid)
        meta_fid.close()
        a = numpy.arange(NUM_ROWS * num_chan * (2 if 'c' in dt else 1))
        if 'i16' in dt:
            b = a.astype(numpy.int16)
        elif 'f32' in dt:
            b = a.astype(numpy.float32)
        elif 'f64' in dt:
            b = a.astype(numpy.float64)
        else:
            raise ValueError('whoops')

        b.tofile(base_filename + '.sigmf-data')

        f = sigmf.sigmffile.fromfile(meta_filename)
        print(f'{dt} with {num_chan} channels: .ndim = {f.ndim} .shape = {f.shape}')
        print(f._memmap[:])
        print(f[:])
        print([i for i in f])
        print()
```