### PR TITLE
Untarless

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,69 @@ assert meta.validate()
 meta.tofile('example.sigmf-meta') # extension is optional
 ```
 
+#### Load a SigMF Archive and slice its data without untaring it
+
+Since an *archive* is merely a tarball (uncompressed), and since there any many
+excellent tools for manipulating tar files, it's fairly straightforward to
+access the *data* part of a SigMF archive without untaring it.
+This is a compelling feature because 1) archives make it harder for the `-data`
+and the `-meta` to get separated, and 2) some datasets are so large that it can
+be impractical (due to available disk space, or slow network speeds if the
+archive file resides on a network file share) or simply obnoxious to untar it
+first.
+
+```python
+In [1]: import sigmf
+
+In [2]: arc = sigmf.SigMFArchiveReader('/src/LTE.sigmf')
+
+In [3]: arc.shape
+Out[3]: (15379532,)
+
+In [4]: arc.ndim
+Out[4]: 1
+
+In [5]: arc[:10]
+Out[5]: 
+array([-20.+11.j, -21. -6.j, -17.-20.j, -13.-52.j,   0.-75.j,  22.-58.j,
+        48.-44.j,  49.-60.j,  31.-56.j,  23.-47.j], dtype=complex64)
+```
+
+The preceeding example exhibits another feature of this approach; the archive
+`LTE.sigmf` is actually `complex-int16`'s on disk, for which there is no
+corresponding type in `numpy`.
+However, the `.sigmffile` member keeps track of this, and converts the data
+to `numpy.complex64` *after* slicing it, that is, after reading it from disk.
+
+```python
+In [6]: arc.sigmffile.get_global_field(sigmf.SigMFFile.DATATYPE_KEY)
+Out[6]: 'ci16_le'
+
+In [7]: arc.sigmffile._memmap.dtype
+Out[7]: dtype('int16')
+
+In [8]: arc.sigmffile._return_type
+Out[8]: '<c8'
+```
+
+Another supported mode is the case where you might have an archive that *is not
+on disk* but instead is simply `bytes` in a python variable.
+Instead of needing to write this out to a temporary file before being able to
+read it, this can be done "in mid air" or "without touching the ground (disk)".
+
+```python
+In [1]: import sigmf, io
+
+In [2]: sigmf_bytes = io.BytesIO(open('/src/LTE.sigmf', 'rb').read())
+
+In [3]: arc = sigmf.SigMFArchiveReader(archive_buffer=sigmf_bytes)
+
+In [4]: arc[:10]
+Out[4]: 
+array([-20.+11.j, -21. -6.j, -17.-20.j, -13.-52.j,   0.-75.j,  22.-58.j,
+        48.-44.j,  49.-60.j,  31.-56.j,  23.-47.j], dtype=complex64)
+```
+
 ## Frequently Asked Questions
 
 ### Is this a GNU Radio effort?

--- a/sigmf/__init__.py
+++ b/sigmf/__init__.py
@@ -22,6 +22,7 @@ __version__ = '1.0.1'
 
 from .archive import SigMFArchive
 from .sigmffile import SigMFFile
+from .archivereader import SigMFArchiveReader
 
 from . import archive
 from . import error
@@ -29,3 +30,4 @@ from . import schema
 from . import sigmffile
 from . import validate
 from . import utils
+from . import archivereader

--- a/sigmf/archivereader.py
+++ b/sigmf/archivereader.py
@@ -1,0 +1,108 @@
+# Copyright 2021 GNU Radio Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Access SigMF archives without extracting them."""
+
+import os
+import shutil
+import tarfile
+import tempfile
+
+from . import __version__  #, schema, sigmf_hash, validate
+from .sigmffile import SigMFFile
+from .archive import SigMFArchive, SIGMF_DATASET_EXT, SIGMF_METADATA_EXT, SIGMF_ARCHIVE_EXT
+from .utils import dict_merge, insert_sorted_dict_list
+from .error import SigMFFileError, SigMFAccessError
+
+
+class SigMFArchiveReader():
+    """Access data within SigMF archive `tar` in-place without extracting.
+
+    Parameters:
+
+      name      -- path to archive file to access. If file does not exist,
+                   or if `name` doesn't end in .sigmf, SigMFFileError is raised.
+    """
+    def __init__(self, name=None, skip_checksum=False, map_readonly=True, archive_buffer=None):
+        self.name = name
+        if self.name is not None:
+            if not name.endswith(SIGMF_ARCHIVE_EXT):
+                err = "archive extension != {}".format(SIGMF_ARCHIVE_EXT)
+                raise error.SigMFFileError(err)
+
+            tar_obj = tarfile.open(self.name)
+
+        elif archive_buffer is not None:
+            tar_obj = tarfile.open(fileobj=archive_buffer, mode='r:')
+
+        else:
+            raise ValueError('In sigmf.archivereader.__init__(), either `name` or `archive_buffer` must be not None')
+
+        json_contents = None
+        data_offset_size = None
+
+        for memb in tar_obj.getmembers():
+            if memb.isdir():  # memb.type == tarfile.DIRTYPE:
+                # the directory structure will be reflected in the member name
+                continue
+
+            elif memb.isfile():  # memb.type == tarfile.REGTYPE:
+                if memb.name.endswith(SIGMF_METADATA_EXT):
+                    json_contents = memb.name
+                    if data_offset_size is None:
+                        # consider a warnings.warn() here; the datafile should be earlier in the
+                        # archive than the metadata, so that updating it (like, adding an annotation)
+                        # is fast.
+                        pass
+                    with tar_obj.extractfile(memb) as memb_fid:
+                        json_contents = memb_fid.read()
+
+                elif memb.name.endswith(SIGMF_DATASET_EXT):
+                    data_offset_size = memb.offset_data, memb.size
+
+                else:
+                    print('A regular file', memb.name, 'was found but ignored in the archive')
+            else:
+                print('A member of type', memb.type, 'and name', memb.name, 'was found but not handled, just FYI.')
+
+        if data_offset_size is None:
+            raise error.SigMFFileError('No .sigmf-data file found in archive!')
+
+        self.sigmffile = SigMFFile(metadata=json_contents)
+        valid_md = self.sigmffile.validate()
+        if not valid_md:
+            print('Metadata in archive did not .validate()!')
+
+        self.sigmffile.set_data_file(self.name, data_buffer=archive_buffer, skip_checksum=skip_checksum, offset=data_offset_size[0],
+                                     size_bytes=data_offset_size[1], map_readonly=map_readonly)
+
+        self.ndim = self.sigmffile.ndim
+        self.shape = self.sigmffile.shape
+
+        tar_obj.close()
+
+    def __len__(self):
+        return self.sigmffile.__len__()
+
+    def __iter__(self):
+        return self.sigmffile.__iter__()
+
+    def __getitem__(self, sli):
+        return self.sigmffile.__getitem__(sli)

--- a/sigmf/error.py
+++ b/sigmf/error.py
@@ -33,7 +33,7 @@ class SigMFValidationError(SigMFError):
 
 class SigMFAccessError(SigMFError):
     """Exceptions related to accessing the contents of SigMF metadata, notably
-    when expexted fields are missing or accessing out of bounds captures."""
+    when expected fields are missing or accessing out of bounds captures."""
     pass
 
 

--- a/sigmf/sigmf_hash.py
+++ b/sigmf/sigmf_hash.py
@@ -21,14 +21,26 @@
 '''Hashing Functions'''
 
 import hashlib
+import os
 
 
-def calculate_sha512(filename):
+def calculate_sha512(filename=None, fileobj=None, offset_and_size=None):
     """
-    Returns sha512 of filename
+    Return sha512 of file or fileobj.
     """
     the_hash = hashlib.sha512()
-    with open(filename, "rb") as handle:
-        for buff in iter(lambda: handle.read(4096), b""):
-            the_hash.update(buff)
+    if filename is not None:
+        fileobj = open(filename, "rb")
+    if offset_and_size is None:
+        bytes_to_hash = os.path.getsize(filename)
+    else:
+        fileobj.seek(offset_and_size[0])
+        bytes_to_hash = offset_and_size[1]
+    bytes_read = 0
+    while bytes_read < bytes_to_hash:
+        buff = fileobj.read(min(4096, (bytes_to_hash - bytes_read)))
+        the_hash.update(buff)
+        bytes_read += len(buff)
+    if filename is not None:
+        fileobj.close()
     return the_hash.hexdigest()

--- a/tests/test_archivereader.py
+++ b/tests/test_archivereader.py
@@ -1,0 +1,54 @@
+import codecs
+import json
+import tarfile
+import tempfile
+from os import path
+
+import numpy as np
+import pytest
+
+from sigmf import error
+from sigmf import SigMFFile, SigMFArchiveReader
+from sigmf.archive import SIGMF_DATASET_EXT, SIGMF_METADATA_EXT
+
+def test_access_data_without_untar(test_sigmffile):
+    global_info = {
+            "core:author": "Glen M",
+            "core:datatype": "ri16_le",
+            "core:license": "https://creativecommons.org/licenses/by-sa/4.0/",
+            "core:num_channels": 2,
+            "core:sample_rate": 48000,
+            "core:version": "1.0.0"
+        }
+    capture_info = {
+            "core:datetime": "2021-06-18T23:17:51.163959Z",
+            "core:sample_start": 0
+        }
+    
+    NUM_ROWS = 5
+
+    for dt in "ri16_le", "ci16_le", "rf32_le", "rf64_le", "cf32_le", "cf64_le":
+        global_info["core:datatype"] = dt
+        for num_chan in 1,3:
+            global_info["core:num_channels"] = num_chan
+            base_filename = dt + '_' + str(num_chan)
+            archive_filename = base_filename + '.sigmf'
+    
+            a = np.arange(NUM_ROWS * num_chan * (2 if 'c' in dt else 1))
+            if 'i16' in dt:
+                b = a.astype(np.int16)
+            elif 'f32' in dt:
+                b = a.astype(np.float32)
+            elif 'f64' in dt:
+                b = a.astype(np.float64)
+            else:
+                raise ValueError('whoops')
+    
+            test_sigmffile.data_file = None
+            with tempfile.NamedTemporaryFile() as temp:
+                b.tofile(temp.name)
+                meta = SigMFFile(data_file=temp.name, global_info=global_info)
+                meta.add_capture(0, metadata=capture_info)
+                meta.tofile(archive_filename, toarchive=True)
+
+                archi = SigMFArchiveReader(archive_filename, skip_checksum=True)


### PR DESCRIPTION
I've now added another class that allows for accessing data without un-tar-ing an archive. The intent is to address the case where an archive is so large that it is onerous/infeasible/obnoxious to unpack it. Please consider exercising this patch with this script:

```python
#!/usr/bin/env python3

import json
import numpy
import sigmf
import warnings

warnings.filterwarnings("always")

global_info = {
        "core:author": "Glen M",
        "core:datatype": "ri16_le",
        "core:license": "https://creativecommons.org/licenses/by-sa/4.0/",
        "core:num_channels": 2,
        "core:sample_rate": 48000,
        "core:version": "1.0.0"
    }
capture_info = {
        "core:datetime": "2021-06-18T23:17:51.163959Z",
        "core:sample_start": 0
    }

NUM_ROWS = 5

for dt in "ri16_le", "ci16_le", "rf32_le", "rf64_le", "cf32_le", "cf64_le":
    global_info["core:datatype"] = dt
    for num_chan in 1,3:
        global_info["core:num_channels"] = num_chan
        base_filename = dt + '_' + str(num_chan)
        archive_filename = base_filename + '.sigmf'
        data_filename = base_filename + '.sigmf-data'

        a = numpy.arange(NUM_ROWS * num_chan * (2 if 'c' in dt else 1))
        if 'i16' in dt:
            b = a.astype(numpy.int16)
        elif 'f32' in dt:
            b = a.astype(numpy.float32)
        elif 'f64' in dt:
            b = a.astype(numpy.float64)
        else:
            raise ValueError('whoops')

        b.tofile(data_filename)
        meta = sigmf.SigMFFile(data_file=data_filename, global_info=global_info)
        meta.add_capture(0, metadata=capture_info)
        meta.tofile(archive_filename, toarchive=True)

        archi = sigmf.SigMFArchiveReader(archive_filename, skip_checksum=True)
        print(f'{dt} with {num_chan} channels: .ndim = {archi.ndim} .shape = {archi.shape}')
        print(archi.sigmffile._memmap[:])
        print(archi[:])
        print([i for i in archi])
        print()
```