### PR TITLE
datatype updates: add double (float64) and fix numpy bit-width error

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ for adx, annotation in enumerate(annotations):
 
 ```python
 import datetime as dt
+import numpy as np
+import sigmf
 from sigmf import SigMFFile
 from sigmf.utils import get_data_type_str
 

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -239,8 +239,8 @@ samples stored in little-endian", the string `"ru16_be"` specifies "real
 unsigned 16-bit samples stored in big-endian", and the string `"cu8"` specifies
 "complex unsigned byte".
 
-Note that only IEEE-754 single-precision floating-point is supported by the
-SigMF Core namespace.
+Note that only IEEE-754 single-precision and double-precision floating-point types
+are supported by the SigMF Core namespace.
 
 The samples SHOULD be written to the Dataset file without separation, and the
 Dataset file MUST NOT contain any other characters (e.g., delimiters,

--- a/sigmf-spec.md
+++ b/sigmf-spec.md
@@ -223,7 +223,7 @@ Dataset formats MAY be added through extensions.
     complex = "c"
 
     type = floating-point / signed-integer / unsigned-integer
-    floating-point = "f32"
+    floating-point = "f32" / "f64"
     signed-integer = "i32" / "i16"
     unsigned-integer = "u32" / "u16"
 

--- a/sigmf/gui.py
+++ b/sigmf/gui.py
@@ -159,7 +159,7 @@ class WindowInput(WindowElementGroup):
         el_text = {}
         el_help = {WindowInput.DATA_BYTE_ORDER: 'Data Type Help'}
         el_multiline = [DESCRIPTION]
-        el_selector = {WindowInput.DATA_SAMPLE_SIZE: [8, 16, 32],
+        el_selector = {WindowInput.DATA_SAMPLE_SIZE: [8, 16, 32, 64],
                        WindowInput.DATA_BYTE_ORDER: ['little endian', 'big endian']}
         el_checkbox = [WindowInput.DATA_TYPE_COMPLEX, WindowInput.DATA_TYPE_UNSIGNED, WindowInput.DATA_TYPE_FIXEDPOINT]
         el_size = {
@@ -316,7 +316,7 @@ def update_capture_screen(capture_data_input, capture_text_blocks, capture_dict)
 def update_global_screen(window_data_input, window_text_blocks, window_dict, archive):
     data_type = window_dict[SigMFFile.DATATYPE_KEY]
     data_info = dtype_info(data_type)
-    sample_size = 32 if '32' in data_type else 16 if '16' in data_type else 8 if '8' in data_type else None
+    sample_size = 64 if '64' in datatype else 32 if '32' in data_type else 16 if '16' in data_type else 8 if '8' in data_type else None
     assert sample_size is not None
     window_text_blocks[WindowInput.DATA_TYPE_FIXEDPOINT].Update(bool(data_info['is_fixedpoint']))
     window_text_blocks[WindowInput.DATA_TYPE_UNSIGNED].Update(bool(data_info['is_unsigned']))
@@ -553,7 +553,7 @@ def main():
                 '\t\tComplex data: \"c\"\n'
                 '\t\tFixedpoint data: \"f\"\n'
                 '\tElementBitSize:\n'
-                '\t\t32 bits, 16 bits, or 8 bits\n'
+                '\t\t64 bits, 32 bits, 16 bits, or 8 bits\n'
                 '\tEndianness:\n'
                 '\t\tl: Little Endian\n'
                 '\t\tb: Big Endian\n\n\n\n'

--- a/sigmf/sigmffile.py
+++ b/sigmf/sigmffile.py
@@ -619,7 +619,9 @@ def dtype_info(datatype):
         else:
             raise SigMFFileError("Unrecognized endianness specifier: '{}'".format(dtype[1]))
     dtype = dtype[0]
-    if "32" in dtype:
+    if "64" in dtype:
+        sample_size = 8
+    elif "32" in dtype:
         sample_size = 4
     elif "16" in dtype:
         sample_size = 2

--- a/sigmf/utils.py
+++ b/sigmf/utils.py
@@ -93,7 +93,10 @@ def get_endian_str(ray):
 
 def get_data_type_str(ray):
     """
-    Return the SigMF datatype string for the datatype of `ray`.
+    Return the SigMF datatype string for the datatype of numpy array `ray`.
+
+    NOTE: this function only supports native numpy types so interleaved complex
+    integer types are not supported.
     """
     if not isinstance(ray, np.ndarray):
         raise error.SigMFError('Argument must be a numpy array')
@@ -104,10 +107,15 @@ def get_data_type_str(ray):
     data_type_str = ''
     if atype.kind == 'c':
         data_type_str += 'cf'
+        # units are component bits, numpy complex types len(I)+len(Q)
+        data_type_str += str(atype.itemsize * 8 // 2)
     elif atype.kind == 'f':
-        data_type_str += 'f'
+        data_type_str += 'rf'
+        data_type_str += str(atype.itemsize * 8)  # units are bits
     elif atype.kind in ('u','i'):
-        data_type_str += atype.kind
-    data_type_str += str(atype.itemsize * 8)  # units is bits
-    data_type_str += get_endian_str(ray)
+        data_type_str += 'r' + atype.kind
+        data_type_str += str(atype.itemsize * 8)  # units are bits
+    if (atype.itemsize > 1):
+        # only append endianness for types over 8 bits
+        data_type_str += get_endian_str(ray)
     return data_type_str

--- a/tests/test_sigmffile.py
+++ b/tests/test_sigmffile.py
@@ -100,6 +100,7 @@ def test_multichannel_types():
         'u32': np.uint32,
         'i32': np.int32,
         'f32': np.float32,
+        'f64': np.float64,
     }
     raw_count = 16
     _, temp_path = tempfile.mkstemp()


### PR DESCRIPTION
Includes relevant commit from #222 (thanks @gmabey) with bug fix.

Fixes issue with converting numpy objects to sigmf datatype names identified in #226 and missing imports in the README example. also allows this function to generate datatype strings for complex integer values.

closes #222
closes #226