### PR TITLE
semantic fixes in extensions

### DIFF
--- a/extensions/adsb.sigmf-ext.md
+++ b/extensions/adsb.sigmf-ext.md
@@ -17,10 +17,10 @@ The following names are specified in the `adsb` namespace and should be used in
 the `annotations` object:
 
 |name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
+|----|--------|----|----|-----------|
 |`downlink_format`|true|int|N/A|Indicates if an ADS-B signal is a Mode S Short (11) or a Mode S Extended (17) signal.|
 |`message_type`|true|int|N/A|Indicates the type of data in a Mode S Extended signal.  The message type code range is from 0 to 31. The type of messages are aircraft identification (1-4), surface position (5-8), airborne position with barometric (9-18), airborne velocities (19), airborne position with GNSS (20-22), testing (23), reserved (24-27, 30), Emergency/Airborne Collision Avoidance System (ACAS) status (28), trajectory change (29), and aircraft operational status (31).  A signal with a Mode S Short downlink format does not contains a message and is represented by 0.
-|`ICA_address`|true|float|N/A|The International Civil Aviation Organization (ICAO) address of the ADS-B signal.|
+|`ICA_address`|true|double|N/A|The International Civil Aviation Organization (ICAO) address of the ADS-B signal.|
 |`binary`|true|string|N/A|The binary signal, either 56 bits (Mode S Short) or 112 bits (Mode S Extended).|
 
 ## 4 Examples

--- a/extensions/antenna.sigmf-ext.md
+++ b/extensions/antenna.sigmf-ext.md
@@ -11,19 +11,19 @@ The following fields are specified for SigMF Recordings.
 The following names are specified in the `antenna` namespace and should be used in the `global` object:
 
 |name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
+|----|--------|----|----|-----------|
 |`model`|true|string|N/A|Antenna make and model number. E.g. `"ARA CSB-16"`, `"L-com HG3512UP-NF"`.|
 |`type`|false|string|N/A|Antenna type. E.g. `"dipole"`, `"biconical"`, `"monopole"`, `"conical monopole"`.|
-|`low_frequency`|false|float|Hz|Low frequency of operational range.|
-|`high_frequency`|false|float|Hz|High frequency of operational range.|
-|`gain`|false|float|dBi|Antenna gain in direction of maximum radiation or reception.|
-|`horizontal_gain_pattern`|false|float array|dBi|Antenna gain pattern in horizontal plane from 0 to 359 degrees in 1 degree steps.|
-|`vertical_gain_pattern`|false|float array|dBi|Antenna gain pattern in vertical plane from -90 to +90 degrees in 1 degree steps.|
-|`horizontal_beam_width`|false|float|degrees|Horizontal 3-dB beamwidth.|
-|`vertical_beam_width`|false|float|degrees|Vertical 3-dB beamwidth.|
-|`cross_polar_discrimination`|false|float|N/A|Cross-polarization discrimination.|
-|`voltage_standing_wave_ratio`|false|float|volts|Voltage standing wave ratio.|
-|`cable_loss`|false|float|dB|Cable loss for cable connecting antenna and preselector.|
+|`low_frequency`|false|double|Hz|Low frequency of operational range.|
+|`high_frequency`|false|double|Hz|High frequency of operational range.|
+|`gain`|false|double|dBi|Antenna gain in direction of maximum radiation or reception.|
+|`horizontal_gain_pattern`|false|double array|dBi|Antenna gain pattern in horizontal plane from 0 to 359 degrees in 1 degree steps.|
+|`vertical_gain_pattern`|false|double array|dBi|Antenna gain pattern in vertical plane from -90 to +90 degrees in 1 degree steps.|
+|`horizontal_beam_width`|false|double|degrees|Horizontal 3-dB beamwidth.|
+|`vertical_beam_width`|false|double|degrees|Vertical 3-dB beamwidth.|
+|`cross_polar_discrimination`|false|double|N/A|Cross-polarization discrimination.|
+|`voltage_standing_wave_ratio`|false|double|volts|Voltage standing wave ratio.|
+|`cable_loss`|false|double|dB|Cable loss for cable connecting antenna and preselector.|
 |`steerable`|false|boolean|N/A|Defines if the antenna is steerable or not.|
 |`mobile`|false|boolean|N/A|Defines if the antenna is mobile or not.|
 |`hagl`|false|double|meters|Antenna phase center height above ground level.|
@@ -37,20 +37,20 @@ The following names are specified in the `antenna` namespace and should be used 
 The following names are specified in the `antenna` namespace and should be used in the `annotations` object:
 
 |name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
-|`azimuth_angle`|false|float|degrees|Angle of main beam in azimuthal plane from North.|
-|`elevation_angle`|false|float|degrees|Angle of main beam in elevation plane from horizontal.|
-|`polarization`|false|float|string|E.g. `"vertical"`, `"horizontal"`, `"slant-45"`, `"left-hand circular"`, `"right-hand circular"`.|
+|----|--------|----|----|-----------|
+|`azimuth_angle`|false|double|degrees|Angle of main beam in azimuthal plane from North.|
+|`elevation_angle`|false|double|degrees|Angle of main beam in elevation plane from horizontal.|
+|`polarization`|false|double|string|E.g. `"vertical"`, `"horizontal"`, `"slant-45"`, `"left-hand circular"`, `"right-hand circular"`.|
 
 ## 4 Collection
 
 The following fields are specificed in SigMF Collections.
 
-|name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
-|`azimuth_angle`|false|float|degrees|Angle of main beam in azimuthal plane from North.|
-|`elevation_angle`|false|float|degrees|Angle of main beam in elevation plane from horizontal.|
-|`hagl`|false|SigMF Recording Tuple|Antenna height above ground level (in meters).|
+|name|required|unit|description|
+|----|--------|----|-----------|
+|`azimuth_angle`|false|degrees|Angle of main beam in azimuthal plane from North.|
+|`elevation_angle`|false|degrees|Angle of main beam in elevation plane from horizontal.|
+|`hagl`|false|meters|Nominal antenna phase center height above ground level.|
 
 ## 5 Examples
 

--- a/extensions/capture_details.sigmf-ext.md
+++ b/extensions/capture_details.sigmf-ext.md
@@ -13,22 +13,22 @@ The following names are specified in the `capture_details` namespace and should
 be used in the `captures` object:
 
 |name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
-|`acq_scale_factor`|true|float|N/A|Scale factor of IQ collection from the spectrum analyzer used to convert back to real power.|
-|`attentuation`|true|float|dB|Input attenuation on the spectrum analyzer.|
-|`acquisition_bandwidth`|true|float|Hz|Frequency range of the IQ recording.|
+|----|--------|----|----|-----------|
+|`acq_scale_factor`|true|double|N/A|Scale factor of IQ collection from the spectrum analyzer used to convert back to real power.|
+|`attentuation`|true|double|dB|Attenuation applied to the input of the sensor.|
+|`acquisition_bandwidth`|true|double|Hz|Bandwidth of the recording (if lower than the `samp_rate`.|
 |`start_capture`|true|string|N/A|Time of the first sample of IQ recording. The time is UTC with the format of `yyyy-mm-ddTHH:MM:SSZ`.|
 |`stop_capture`|true|string|N/A|Time of the last sample of IQ recording. The time is UTC with the format of `yyyy-mm-ddTHH:MM:SSZ`.|
 |`source_file`|true|string|N/A|RF IQ recording filename that was used to create the file `N.sigmf-data`.  The file `N.sigmf-data` may be the same or an edited versions of the `source_file`.|
-|`gain`|false|float|dB|Input gain.|
+|`gain`|false|double|dB|Gain setting of the sensor for this acquisition, distilled to a single number.|
 
 ## 3 Annotations
 
 The following names are specified in the `capture_details` namespace and should be used in the `annotations` object:
 
 |name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
-|`SNRdB`|true|float|dB|Root mean square (RMS) calculation of signal to noise ratio (SNR). The calculation is over windows of known signal and no known signal.|
+|----|--------|----|----|-----------|
+|`SNRdB`|true|double|dB|Root mean square (RMS) calculation of signal to noise ratio (SNR). The calculation is over windows of known signal and no known signal.|
 |`signal_reference_number`|true|string|N/A|Sequential reference labels for the elements that form the sequence of signals identified in a SigMF dataset file. The format of the string is the filename followed by an index that increases with each decoded signal.  An example is a recording dataset file named `N.sigmf-data` would have signal numbers starting with `N-1`, `N-2`, `N-3`...|
 
 ## 4 Examples

--- a/extensions/rfml.sigmf-ext.md
+++ b/extensions/rfml.sigmf-ext.md
@@ -9,8 +9,8 @@ The following names are specified in the `rfml` namespace and should be used in
 the `global` object:
 
 |name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
-|`label_hierarchy`|true|string array|N/A|Defines hierarchy of the fields in the label array.|
+|----|--------|----|----|-----------|
+|`label_hierarchy`|true|array|N/A|An array of strings defining the hierarchy of the fields in the label array.|
 
 ## 2 Captures
 
@@ -22,8 +22,8 @@ The following names are specified in the `rfml` namespace and should be used in
 the `annotations` object:
 
 |name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
-|`label`|true|string array|N/A|An array of hierarchical labels that describe this annotation. The label `device_type` is the type of RF transmitter or signal source.  The label `manufacturer_ID` is the manufacturer of the transmitter. The label `device_ID` is the source of the RF signal.|
+|----|--------|----|----|-----------|
+|`label`|true|array|N/A|An array of strings representing hierarchical labels that describe this annotation. The label `device_type` is the type of RF transmitter or signal source.  The label `manufacturer_ID` is the manufacturer of the transmitter. The label `device_ID` is the source of the RF signal.|
 
 ## 4 Examples
 

--- a/extensions/signal.sigmf-ext.md
+++ b/extensions/signal.sigmf-ext.md
@@ -18,7 +18,7 @@ the attributes of wireless communications signals and their emitters.
 This extension adds the following optional field to the `annotations` global SigMF object:
 
 |name|required|type|description|
-|----|--------------|-------|----------|
+|----|--------|----|----|-----------|
 |`detail`|false|[Detail](signal.sigmf-ext.md#the-detail-object)|Emission details (standard, modulation, etc.)|
 |`emitter`|false|[Emitter](signal.sigmf-ext.md#the-emitter-object)|Emitter details (manufacturer, geo coordinates, etc.)|
 
@@ -42,7 +42,7 @@ the new fields to be upstreamed into this canonical extension.
 |`multiplexing`|false|string|[multiplexing](signal.sigmf-ext.md#the-multiplexing-field)|
 |`multiple_access`|false|string|[multiple access](signal.sigmf-ext.md#the-multiple_access-field)|
 |`spreading`|false|string|[spreading](signal.sigmf-ext.md#the-spreading-field)|
-|`channel_bw`|false|float|[bandwidth](signal.sigmf-ext.md#the-bandwidth-field)|
+|`channel_bw`|false|double|[bandwidth](signal.sigmf-ext.md#the-bandwidth-field)|
 |`channel`|false|uint|[channel](signal.sigmf-ext.md#the-channel-field)|
 |`class_variant`|false|string|[class variant](signal.sigmf-ext.md#the-class_variant-field)|
 
@@ -150,7 +150,7 @@ The `spreading` field can have the following values:
 
 #### 3.1.10 The `bandwidth` Field
 
-The `channel_bw` field has a float value that describes the channel bandwidth of
+The `channel_bw` field has a numeric value describing the channel bandwidth of
 the signal. Note that this is different from what may be reported in the `core`
 namespace within an annotation which describes the occupied spectrum of a
 signal, which may or may not be comparable to the actual channel bandwidth of

--- a/extensions/wifi.sigmf-ext.md
+++ b/extensions/wifi.sigmf-ext.md
@@ -16,13 +16,13 @@ The `wifi`namespace extension defines dynamic Wi-Fi burst parameters extending
 The following names are specified in the `wifi` namespace and should be used in the `annotations` object:
 
 |name|required|type|unit|description|
-|----|--------------|-------|-------|-----------|
+|----|--------|----|----|-----------|
 |`standard`|true|string|N/A|Wireless standard of captured signal e.g. 802.11a/g.|
 |`frame_type_phy`|true|string|N/A|Physical layer specification e.g. non-high throughput or very-high throughput.|
 |`channel`|true|int|N/A|Wi-Fi channel of captured signal|
-|`start_time_s`|true|float|seconds|Start time of RF burst (relative time to start time of main capture file).|
-|`stop_time_s`|true|float|seconds|Stop time of RF burst (relative time to start time of main capture file).|
-|`frame_duration_s`|true|float|seconds|Duration of RF burst (`stop_time_s` - `start_time_s`).|
+|`start_time_s`|true|double|seconds|Start time of RF burst (relative time to start time of main capture file).|
+|`stop_time_s`|true|double|seconds|Stop time of RF burst (relative time to start time of main capture file).|
+|`frame_duration_s`|true|double|seconds|Duration of RF burst (`stop_time_s` - `start_time_s`).|
 |`MCS`|true|int|N/A|Wi-Fi signal Modulation and Coding Scheme (MCS).|
 |`MAC_frame_type`|true|string|N/A|Wi-Fi MAC frame type.|
 |`MAC_ta`|true|string|N/A|Wi-Fi transmitter MAC address.|
@@ -30,9 +30,9 @@ The following names are specified in the `wifi` namespace and should be used in 
 |`manufacturer_ta`|true|string|N/A|Manufacturer of the Wi-Fi transmitter.|
 |`MAC_frame`|true|string|N/A|Wi-Fi MAC frame data without CRC.|
 |`CRC`|true|string|N/A|Wi-Fi MAC frame CRC.|
-|`start_of_packet`|true|float|samples|Starting sample of captured Wi-Fi burst.|
-|`stop_of_packet`|true|float|samples|Stopping sample of captured Wi-Fi burst.|
-|`number_of_samples_in_packet`|true|float|samples|Number of downsampled IQ samples in Wi-Fi burst.|
+|`start_of_packet`|true|double|samples|Starting sample of captured Wi-Fi burst.|
+|`stop_of_packet`|true|double|samples|Stopping sample of captured Wi-Fi burst.|
+|`number_of_samples_in_packet`|true|double|samples|Number of downsampled IQ samples in Wi-Fi burst.|
 
 ## 4 Examples
 


### PR DESCRIPTION
Minor fixes: addressing a table issue in the `antenna` extension, avoiding defining units for collections in extensions (which are specified in the SigMF Recordings) and using standard language for units: "array" instead of "array of xxx"/"xxx array" and "double" instead of "float".