### PR TITLE
update build config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
 [aliases]
 test=pytest
-
-[wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,14 @@ setup(
     long_description=longdesc,
     url='https://github.com/gnuradio/SigMF',
     classifiers=[
+        'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
+        'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
     entry_points={
         'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skip_missing_interpreters = True
-envlist = py27, py34, py35, py36, py37
+envlist = py36, py37, py38, py39, py310
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Will no longer build 2.x support and updated classifiers and envlist. Specifies support for 3.6 - 3.10.

I am not an expert here, but I think this is what we want this to do....