### PR TITLE
fixed & updated CITATION

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,10 +1,9 @@
 cff-version: 1.0.3
-message: To cite the SigMF specification, please include the following:
 authors:
   - name: The GNU Radio Foundation, Inc.
 title: The Signal Metadata Format (SigMF)
-version: 0.0.1
+version: 1.2.5
 doi: 10.5281/zenodo.1418396
-date-released: 2018-07-18
+date-released: 2025-05-16
 license: CC-BY-SA-4.0
 url: https://sigmf.org


### PR DESCRIPTION
Should close #348.

I believe the authors field should probably be updated to the contributors to the repo or `multiple authors` or similar. We don't really have a SigMF ORG yet, but perhaps we should?