### PR TITLE
Allow global.properties.core:sample_rate to be any number greater than 0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.0.3
 authors:
   - name: The GNU Radio Foundation, Inc.
 title: The Signal Metadata Format (SigMF)
-version: 1.2.5
+version: 1.2.6
 doi: 10.5281/zenodo.1418396
 date-released: 2025-05-16
 license: CC-BY-SA-4.0

--- a/sigmf-schema.json
+++ b/sigmf-schema.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/sigmf/SigMF/v1.2.5/sigmf-schema.json",
+  "$id": "https://raw.githubusercontent.com/sigmf/SigMF/v1.2.6/sigmf-schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Schema for SigMF Meta Files",
   "description": "SigMF specifies a way to describe sets of recorded digital signal samples with metadata written in JSON. SigMF can be used to describe general information about a collection of samples, the characteristics of the system that generated the samples, features of signals themselves, and the relationship between different recordings.",

--- a/sigmf-schema.json
+++ b/sigmf-schema.json
@@ -30,7 +30,7 @@
         },
         "core:sample_rate": {
           "description": "The sample rate of the signal in samples per second.",
-          "minimum": 1,
+          "exclusiveMinimum": 0,
           "maximum": 1000000000000,
           "type": "number"
         },


### PR DESCRIPTION
See https://github.com/sigmf/SigMF/issues/339 for discussion. There are cases where the sample rate of a system is less than 1 second. This change makes use of the [JSON schema `exclusiveMinimum` keyword on ranges](https://json-schema.org/understanding-json-schema/reference/numeric#range).